### PR TITLE
feat: implement forum answer functionality

### DIFF
--- a/src/community/forum/answer/handler.ts
+++ b/src/community/forum/answer/handler.ts
@@ -1,0 +1,184 @@
+import type { Context } from "hono";
+import type {
+  AnswerIdParams,
+  CreateAnswerInput,
+  QuestionIdParams,
+  UpdateAnswerInput,
+  VoteAnswerInput,
+} from "./schema";
+import {
+  createAnswer,
+  findAnswerById,
+  findAnswersByQuestionId,
+  findQuestionById,
+  setAnswerVote,
+  softDeleteAnswer,
+  updateAnswer,
+} from "./query";
+import { POSTGRES_FOREIGN_KEY_VIOLATION } from "../constants";
+import { getValidatedForumAuthUserId } from "../utils/auth";
+
+export async function handleGetAnswers(c: Context, params: QuestionIdParams) {
+  const authResult = getValidatedForumAuthUserId(c);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  try {
+    const question = await findQuestionById(params.questionId);
+    if (!question || question.status === "DELETED") {
+      return c.json({ ok: false, error: "Question not found" }, 404);
+    }
+
+    const answers = await findAnswersByQuestionId(params.questionId, authResult.userId);
+    return c.json({ ok: true, answers }, 200);
+  } catch (err) {
+    console.error("Failed to get answers", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
+  }
+}
+
+export async function handleCreateAnswer(c: Context, data: CreateAnswerInput) {
+  const authResult = getValidatedForumAuthUserId(c);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  try {
+    const question = await findQuestionById(data.questionId);
+    if (!question) {
+      return c.json({ ok: false, error: "Question not found" }, 404);
+    }
+
+    if (question.status !== "PUBLISHED") {
+      return c.json(
+        { ok: false, error: "Answers can only be posted to published questions" },
+        409,
+      );
+    }
+
+    const newAnswer = await createAnswer(data, authResult.userId);
+    return c.json({ ok: true, answer: newAnswer }, 201);
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === POSTGRES_FOREIGN_KEY_VIOLATION) {
+      return c.json({ ok: false, error: "Question not found" }, 404);
+    }
+    console.error("Failed to create answer", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
+  }
+}
+
+export async function handleEditAnswer(
+  c: Context,
+  params: AnswerIdParams,
+  data: UpdateAnswerInput,
+) {
+  const authResult = getValidatedForumAuthUserId(c);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  try {
+    const existingAnswer = await findAnswerById(params.answerId);
+    if (!existingAnswer) {
+      return c.json({ ok: false, error: "Answer not found" }, 404);
+    }
+
+    if (existingAnswer.authorId !== authResult.userId) {
+      return c.json({ ok: false, error: "You can only edit your own answer" }, 403);
+    }
+
+    if (existingAnswer.status !== "PUBLISHED") {
+      return c.json({ ok: false, error: "Only published answers can be edited" }, 409);
+    }
+
+    const updatedAnswer = await updateAnswer(params.answerId, authResult.userId, data);
+    if (!updatedAnswer) {
+      return c.json({ ok: false, error: "Answer not found" }, 404);
+    }
+
+    return c.json({ ok: true, answer: updatedAnswer }, 200);
+  } catch (err) {
+    console.error("Failed to edit answer", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
+  }
+}
+
+export async function handleDeleteAnswer(c: Context, params: AnswerIdParams) {
+  const authResult = getValidatedForumAuthUserId(c);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  try {
+    const existingAnswer = await findAnswerById(params.answerId);
+    if (!existingAnswer) {
+      return c.json({ ok: false, error: "Answer not found" }, 404);
+    }
+
+    if (existingAnswer.authorId !== authResult.userId) {
+      return c.json({ ok: false, error: "You can only delete your own answer" }, 403);
+    }
+
+    if (existingAnswer.status !== "PUBLISHED") {
+      return c.json({ ok: false, error: "Answer is already deleted" }, 409);
+    }
+
+    const deletedAnswer = await softDeleteAnswer(params.answerId, authResult.userId);
+    if (!deletedAnswer) {
+      return c.json({ ok: false, error: "Answer not found" }, 404);
+    }
+
+    return c.json({ ok: true }, 200);
+  } catch (err) {
+    console.error("Failed to delete answer", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
+  }
+}
+
+export async function handleVoteAnswer(
+  c: Context,
+  params: AnswerIdParams,
+  data: VoteAnswerInput,
+) {
+  const authResult = getValidatedForumAuthUserId(c);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  try {
+    const existingAnswer = await findAnswerById(params.answerId);
+    if (!existingAnswer) {
+      return c.json({ ok: false, error: "Answer not found" }, 404);
+    }
+
+    if (existingAnswer.status !== "PUBLISHED") {
+      return c.json({ ok: false, error: "Only published answers can be voted on" }, 409);
+    }
+
+    if (existingAnswer.authorId === authResult.userId) {
+      return c.json({ ok: false, error: "You cannot vote on your own answer" }, 409);
+    }
+
+    const votedAnswer = await setAnswerVote(
+      params.answerId,
+      authResult.userId,
+      data.voteType,
+    );
+    if (!votedAnswer) {
+      return c.json({ ok: false, error: "Answer not found" }, 404);
+    }
+
+    return c.json(
+      {
+        ok: true,
+        answer: votedAnswer,
+      },
+      200,
+    );
+  } catch (err) {
+    console.error("Failed to vote answer", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
+  }
+}

--- a/src/community/forum/answer/index.ts
+++ b/src/community/forum/answer/index.ts
@@ -1,0 +1,65 @@
+import { Hono } from "hono";
+import { requireAccessToken } from "../../../auth/middleware";
+import {
+  handleCreateAnswer,
+  handleDeleteAnswer,
+  handleEditAnswer,
+  handleGetAnswers,
+  handleVoteAnswer,
+} from "./handler";
+import {
+  answerIdParamsValidator,
+  createAnswerValidator,
+  questionIdParamsValidator,
+  updateAnswerValidator,
+  voteAnswerValidator,
+} from "./validator";
+
+export const communityForumAnswerFeature = new Hono();
+
+communityForumAnswerFeature.use("*", requireAccessToken);
+
+communityForumAnswerFeature.get(
+  "/get-answers/:questionId",
+  questionIdParamsValidator,
+  async (c) => {
+    const params = c.req.valid("param");
+    return handleGetAnswers(c, params);
+  },
+);
+
+communityForumAnswerFeature.post("/create-answer", createAnswerValidator, async (c) => {
+  const data = c.req.valid("json");
+  return handleCreateAnswer(c, data);
+});
+
+communityForumAnswerFeature.patch(
+  "/edit-answer/:answerId",
+  answerIdParamsValidator,
+  updateAnswerValidator,
+  async (c) => {
+    const params = c.req.valid("param");
+    const data = c.req.valid("json");
+    return handleEditAnswer(c, params, data);
+  },
+);
+
+communityForumAnswerFeature.delete(
+  "/delete-answer/:answerId",
+  answerIdParamsValidator,
+  async (c) => {
+    const params = c.req.valid("param");
+    return handleDeleteAnswer(c, params);
+  },
+);
+
+communityForumAnswerFeature.post(
+  "/vote-answer/:answerId",
+  answerIdParamsValidator,
+  voteAnswerValidator,
+  async (c) => {
+    const params = c.req.valid("param");
+    const data = c.req.valid("json");
+    return handleVoteAnswer(c, params, data);
+  },
+);

--- a/src/community/forum/answer/query.ts
+++ b/src/community/forum/answer/query.ts
@@ -1,0 +1,250 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "../../../db/index";
+import { forumAnswer, forumAnswerVote, forumQuestion } from "../../../db/schema";
+import type {
+  AnswerVoteType,
+  CreateAnswerInput,
+  UpdateAnswerInput,
+  VoteIntent,
+} from "./schema";
+
+type ForumQuestionRow = typeof forumQuestion.$inferSelect;
+type ForumAnswerRow = typeof forumAnswer.$inferSelect;
+type ForumAnswerInsert = typeof forumAnswer.$inferInsert;
+type ForumAnswerVoteInsert = typeof forumAnswerVote.$inferInsert;
+type ForumAnswerWithViewerVote = ForumAnswerRow & {
+  score: number;
+  viewerVote: AnswerVoteType | null;
+};
+
+function toInteger(value: unknown, fallback = 0): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function hydrateAnswer(
+  answer: ForumAnswerRow,
+  viewerVote: AnswerVoteType | null,
+): ForumAnswerWithViewerVote {
+  return {
+    ...answer,
+    score: answer.upvoteCount - answer.downvoteCount,
+    viewerVote,
+  };
+}
+
+export async function findQuestionById(id: string): Promise<ForumQuestionRow | null> {
+  const rows = await db.select().from(forumQuestion).where(eq(forumQuestion.id, id));
+  return rows[0] ?? null;
+}
+
+export async function findAnswerById(id: string): Promise<ForumAnswerRow | null> {
+  const rows = await db.select().from(forumAnswer).where(eq(forumAnswer.id, id));
+  return rows[0] ?? null;
+}
+
+export async function findAnswersByQuestionId(
+  questionId: string,
+  viewerId: string,
+): Promise<ForumAnswerWithViewerVote[]> {
+  const rows = await db
+    .select({
+      answer: forumAnswer,
+      viewerVoteType: forumAnswerVote.voteType,
+    })
+    .from(forumAnswer)
+    .leftJoin(
+      forumAnswerVote,
+      and(
+        eq(forumAnswerVote.answerId, forumAnswer.id),
+        eq(forumAnswerVote.voterId, viewerId),
+      ),
+    )
+    .where(and(eq(forumAnswer.questionId, questionId), eq(forumAnswer.status, "PUBLISHED")))
+    .orderBy(desc(forumAnswer.upvoteCount), desc(forumAnswer.createdAt));
+
+  return rows.map((row) =>
+    hydrateAnswer(
+      row.answer,
+      row.viewerVoteType ? (row.viewerVoteType as AnswerVoteType) : null,
+    ),
+  );
+}
+
+export async function createAnswer(
+  data: CreateAnswerInput,
+  authorId: string,
+): Promise<ForumAnswerWithViewerVote> {
+  return db.transaction(async (tx) => {
+    const answerInsertData: ForumAnswerInsert = {
+      questionId: data.questionId,
+      authorId,
+      body: data.body,
+      status: "PUBLISHED",
+      upvoteCount: 0,
+      downvoteCount: 0,
+    };
+
+    const [newAnswer] = await tx.insert(forumAnswer).values(answerInsertData).returning();
+
+    await tx
+      .update(forumQuestion)
+      .set({
+        answerCount: sql`greatest(${forumQuestion.answerCount} + 1, 0)`,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(forumQuestion.id, data.questionId));
+
+    return hydrateAnswer(newAnswer, null);
+  });
+}
+
+export async function updateAnswer(
+  answerId: string,
+  authorId: string,
+  data: UpdateAnswerInput,
+): Promise<ForumAnswerWithViewerVote | null> {
+  const [updatedAnswer] = await db
+    .update(forumAnswer)
+    .set({
+      body: data.body,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(forumAnswer.id, answerId),
+        eq(forumAnswer.authorId, authorId),
+        eq(forumAnswer.status, "PUBLISHED"),
+      ),
+    )
+    .returning();
+
+  return updatedAnswer ? hydrateAnswer(updatedAnswer, null) : null;
+}
+
+export async function softDeleteAnswer(
+  answerId: string,
+  authorId: string,
+): Promise<ForumAnswerRow | null> {
+  return db.transaction(async (tx) => {
+    const [deletedAnswer] = await tx
+      .update(forumAnswer)
+      .set({
+        status: "DELETED",
+        deletedAt: sql`now()`,
+        updatedAt: sql`now()`,
+      })
+      .where(
+        and(
+          eq(forumAnswer.id, answerId),
+          eq(forumAnswer.authorId, authorId),
+          eq(forumAnswer.status, "PUBLISHED"),
+        ),
+      )
+      .returning();
+
+    if (!deletedAnswer) {
+      return null;
+    }
+
+    await tx
+      .update(forumQuestion)
+      .set({
+        answerCount: sql`greatest(${forumQuestion.answerCount} - 1, 0)`,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(forumQuestion.id, deletedAnswer.questionId));
+
+    return deletedAnswer;
+  });
+}
+
+export async function setAnswerVote(
+  answerId: string,
+  voterId: string,
+  voteIntent: VoteIntent,
+): Promise<ForumAnswerWithViewerVote | null> {
+  return db.transaction(async (tx) => {
+    // Namespaced advisory lock: (100 = forum domain, hash(answerId) = per-answer vote serialisation).
+    await tx.execute(sql`select pg_advisory_xact_lock(100, hashtext(${answerId}))`);
+
+    const [answer] = await tx
+      .select()
+      .from(forumAnswer)
+      .where(and(eq(forumAnswer.id, answerId), eq(forumAnswer.status, "PUBLISHED")));
+
+    if (!answer) {
+      return null;
+    }
+
+    if (voteIntent === "NONE") {
+      await tx
+        .delete(forumAnswerVote)
+        .where(
+          and(
+            eq(forumAnswerVote.answerId, answerId),
+            eq(forumAnswerVote.voterId, voterId),
+          ),
+        );
+    } else {
+      const voteInsertData: ForumAnswerVoteInsert = {
+        answerId,
+        voterId,
+        voteType: voteIntent,
+      };
+
+      await tx
+        .insert(forumAnswerVote)
+        .values(voteInsertData)
+        .onConflictDoUpdate({
+          target: [forumAnswerVote.answerId, forumAnswerVote.voterId],
+          set: {
+            voteType: voteIntent,
+            updatedAt: sql`now()`,
+          },
+        });
+    }
+
+    const [voteCountRow] = await tx
+      .select({
+        upvoteCount:
+          sql`coalesce(sum(case when ${forumAnswerVote.voteType} = 'UPVOTE' then 1 else 0 end), 0)`,
+        downvoteCount:
+          sql`coalesce(sum(case when ${forumAnswerVote.voteType} = 'DOWNVOTE' then 1 else 0 end), 0)`,
+      })
+      .from(forumAnswerVote)
+      .where(eq(forumAnswerVote.answerId, answerId));
+
+    const normalizedUpvoteCount = toInteger(voteCountRow?.upvoteCount);
+    const normalizedDownvoteCount = toInteger(voteCountRow?.downvoteCount);
+
+    const [updatedAnswer] = await tx
+      .update(forumAnswer)
+      .set({
+        upvoteCount: normalizedUpvoteCount,
+        downvoteCount: normalizedDownvoteCount,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(forumAnswer.id, answerId))
+      .returning();
+
+    if (!updatedAnswer) {
+      return null;
+    }
+
+    const [viewerVoteRow] = await tx
+      .select({
+        voteType: forumAnswerVote.voteType,
+      })
+      .from(forumAnswerVote)
+      .where(
+        and(eq(forumAnswerVote.answerId, answerId), eq(forumAnswerVote.voterId, voterId)),
+      )
+      .limit(1);
+
+    return hydrateAnswer(
+      updatedAnswer,
+      viewerVoteRow?.voteType ? (viewerVoteRow.voteType as AnswerVoteType) : null,
+    );
+  });
+}

--- a/src/community/forum/answer/schema.ts
+++ b/src/community/forum/answer/schema.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { FORUM_UUID_RE } from "../constants";
+
+const MAX_ANSWER_BODY_LENGTH = 10000;
+
+const answerBodySchema = z
+  .string()
+  .trim()
+  .min(1, `body is required and must be 1..${MAX_ANSWER_BODY_LENGTH} characters`)
+  .max(
+    MAX_ANSWER_BODY_LENGTH,
+    `body is required and must be 1..${MAX_ANSWER_BODY_LENGTH} characters`,
+  );
+
+export const answerIdParamsSchema = z.object({
+  answerId: z.string().trim().regex(FORUM_UUID_RE, "answerId must be a valid UUID"),
+});
+
+export type AnswerIdParams = z.infer<typeof answerIdParamsSchema>;
+
+export const questionIdParamsSchema = z.object({
+  questionId: z.string().trim().regex(FORUM_UUID_RE, "questionId must be a valid UUID"),
+});
+
+export type QuestionIdParams = z.infer<typeof questionIdParamsSchema>;
+
+export const createAnswerSchema = z
+  .object({
+    questionId: z
+      .string()
+      .trim()
+      .regex(FORUM_UUID_RE, "questionId is required and must be a valid UUID"),
+    body: answerBodySchema,
+  })
+  .transform((value) => ({
+    questionId: value.questionId,
+    body: value.body,
+  }));
+
+export type CreateAnswerInput = z.infer<typeof createAnswerSchema>;
+
+export const updateAnswerSchema = z
+  .object({
+    body: answerBodySchema,
+  })
+  .transform((value) => ({
+    body: value.body,
+  }));
+
+export type UpdateAnswerInput = z.infer<typeof updateAnswerSchema>;
+
+const voteIntentSchema = z.enum(["UPVOTE", "DOWNVOTE", "NONE"]);
+
+export type VoteIntent = z.infer<typeof voteIntentSchema>;
+export type AnswerVoteType = Exclude<VoteIntent, "NONE">;
+
+const normalizedVoteIntentSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .pipe(voteIntentSchema);
+
+export const voteAnswerSchema = z
+  .object({
+    voteType: normalizedVoteIntentSchema,
+  })
+  .transform((value) => ({
+    voteType: value.voteType,
+  }));
+
+export type VoteAnswerInput = z.infer<typeof voteAnswerSchema>;

--- a/src/community/forum/answer/validator.ts
+++ b/src/community/forum/answer/validator.ts
@@ -1,0 +1,100 @@
+import type { Context } from "hono";
+import { z } from "zod";
+import type { ZodTypeAny } from "zod";
+import { validator } from "hono/validator";
+import {
+  answerIdParamsSchema,
+  createAnswerSchema,
+  questionIdParamsSchema,
+  updateAnswerSchema,
+  voteAnswerSchema,
+} from "./schema";
+
+type FieldErrors = Record<string, string>;
+type ValidationFailure = {
+  ok: false;
+  message: string;
+  fieldErrors?: FieldErrors;
+};
+type ValidationSuccess<T> = { ok: true; data: T };
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+function parseWithSchema<TSchema extends ZodTypeAny>(
+  schema: TSchema,
+  input: unknown,
+): ValidationResult<z.infer<TSchema>> {
+  if (typeof input !== "object" || input === null) {
+    return { ok: false, message: "Invalid input" };
+  }
+
+  const parsed = schema.safeParse(input);
+  if (!parsed.success) {
+    const fieldErrors: FieldErrors = {};
+
+    for (const issue of parsed.error.issues) {
+      const path =
+        issue.path.length > 0
+          ? issue.path.map((segment) => String(segment)).join(".")
+          : "body";
+      const isMissingField =
+        issue.code === "invalid_type" &&
+        "received" in issue &&
+        issue.received === "undefined" &&
+        issue.path.length > 0;
+      const message = isMissingField ? `${path} is required` : issue.message;
+
+      if (!fieldErrors[path]) {
+        fieldErrors[path] = message;
+      }
+    }
+
+    const firstField = Object.keys(fieldErrors).sort((a, b) => a.localeCompare(b))[0];
+
+    return {
+      ok: false,
+      message: firstField ? fieldErrors[firstField] : "Validation failed",
+      fieldErrors,
+    };
+  }
+
+  return { ok: true, data: parsed.data };
+}
+
+function buildValidationErrorResponse(c: Context, payload: ValidationFailure) {
+  return c.json(
+    {
+      ok: false,
+      error: "Validation failed",
+      message: payload.message,
+      ...(payload.fieldErrors ? { fieldErrors: payload.fieldErrors } : {}),
+    },
+    400,
+  );
+}
+
+function validateWithSchema<TSchema extends ZodTypeAny>(schema: TSchema) {
+  return (value: unknown, c: Context) => {
+    const parsed = parseWithSchema(schema, value);
+    if (!parsed.ok) {
+      return buildValidationErrorResponse(c, parsed);
+    }
+
+    return parsed.data;
+  };
+}
+
+export const createAnswerValidator = validator("json", validateWithSchema(createAnswerSchema));
+
+export const updateAnswerValidator = validator("json", validateWithSchema(updateAnswerSchema));
+
+export const voteAnswerValidator = validator("json", validateWithSchema(voteAnswerSchema));
+
+export const answerIdParamsValidator = validator(
+  "param",
+  validateWithSchema(answerIdParamsSchema),
+);
+
+export const questionIdParamsValidator = validator(
+  "param",
+  validateWithSchema(questionIdParamsSchema),
+);

--- a/src/community/forum/constants.ts
+++ b/src/community/forum/constants.ts
@@ -1,0 +1,4 @@
+export const FORUM_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const POSTGRES_FOREIGN_KEY_VIOLATION = "23503";

--- a/src/community/forum/questions/handler.ts
+++ b/src/community/forum/questions/handler.ts
@@ -14,6 +14,8 @@ import {
   findQuestionsPage,
 } from "./query";
 
+const POSTGRES_FOREIGN_KEY_VIOLATION = "23503";
+
 export async function handleGetQuestions(c: Context) {
   try {
     const questions = await findAllQuestions();
@@ -93,7 +95,7 @@ export async function handleCreateQuestion(c: Context, data: CreateQuestionInput
     return c.json({ ok: true, question: newQuestion }, 201);
   } catch (err) {
     const code = (err as { code?: string } | null)?.code;
-    if (code === "23503") {
+    if (code === POSTGRES_FOREIGN_KEY_VIOLATION) {
       return c.json({ ok: false, error: "Category not found" }, 404);
     }
     console.error("Failed to create question", err);

--- a/src/community/forum/utils/auth.ts
+++ b/src/community/forum/utils/auth.ts
@@ -1,0 +1,33 @@
+import type { Context } from "hono";
+import { getAuthUserId, type AuthPayload } from "../../../auth/types";
+import { FORUM_UUID_RE } from "../constants";
+
+export function getValidatedForumAuthUserId(
+  c: Context,
+): { ok: true; userId: string } | { ok: false; response: Response } {
+  const authPayload = c.get("auth") as AuthPayload | undefined;
+  const userId = getAuthUserId(authPayload);
+
+  if (!userId) {
+    return {
+      ok: false,
+      response: c.json({ ok: false, error: "Authenticated user id not found" }, 401),
+    };
+  }
+
+  if (!FORUM_UUID_RE.test(userId)) {
+    return {
+      ok: false,
+      response: c.json(
+        {
+          ok: false,
+          error:
+            "Authenticated user id is not UUID. Align forum author_id type with auth user id type.",
+        },
+        400,
+      ),
+    };
+  }
+
+  return { ok: true, userId };
+}

--- a/src/db/schema/forum.ts
+++ b/src/db/schema/forum.ts
@@ -30,6 +30,11 @@ export const forumAnswerStatus = pgEnum("forum_answer_status", [
   "DELETED",
 ]);
 
+export const forumAnswerVoteType = pgEnum("forum_answer_vote_type", [
+  "UPVOTE",
+  "DOWNVOTE",
+]);
+
 export const forumCategory = pgTable(
   "forum_category",
   {
@@ -91,10 +96,39 @@ export const forumAnswer = pgTable(
   "forum_answer",
   {
     id: uuid("id").defaultRandom().primaryKey().notNull(),
-    questionId: uuid("question_id").notNull(),
+    questionId: uuid("question_id")
+      .notNull()
+      .references(() => forumQuestion.id, { onDelete: "cascade" }),
     authorId: uuid("author_id").notNull(),
     body: text("body").notNull(),
     status: forumAnswerStatus("status").default("PUBLISHED").notNull(),
+    upvoteCount: integer("upvote_count").default(0).notNull(),
+    downvoteCount: integer("downvote_count").default(0).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true, mode: "string" })
+      .defaultNow()
+      .notNull(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true, mode: "string" }),
+  },
+  (table) => [
+    index("forum_answer_question_idx").using("btree", table.questionId),
+    index("forum_answer_author_idx").using("btree", table.authorId),
+    index("forum_answer_status_idx").using("btree", table.status),
+    index("forum_answer_created_idx").using("btree", table.createdAt),
+  ],
+);
+
+export const forumAnswerVote = pgTable(
+  "forum_answer_vote",
+  {
+    id: uuid("id").defaultRandom().primaryKey().notNull(),
+    answerId: uuid("answer_id")
+      .notNull()
+      .references(() => forumAnswer.id, { onDelete: "cascade" }),
+    voterId: uuid("voter_id").notNull(),
+    voteType: forumAnswerVoteType("vote_type").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "string" })
       .defaultNow()
       .notNull(),
@@ -103,9 +137,13 @@ export const forumAnswer = pgTable(
       .notNull(),
   },
   (table) => [
-    index("forum_answer_question_idx").using("btree", table.questionId),
-    index("forum_answer_author_idx").using("btree", table.authorId),
-    index("forum_answer_status_idx").using("btree", table.status),
-    index("forum_answer_created_idx").using("btree", table.createdAt),
+    uniqueIndex("forum_answer_vote_answer_voter_unique_idx").using(
+      "btree",
+      table.answerId,
+      table.voterId,
+    ),
+    index("forum_answer_vote_answer_idx").using("btree", table.answerId),
+    index("forum_answer_vote_voter_idx").using("btree", table.voterId),
+    index("forum_answer_vote_type_idx").using("btree", table.voteType),
   ],
 );

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -15,6 +15,7 @@ export const openApiDoc = {
     { name: "Auth" },
     { name: "Forum Category" },
     { name: "Forum Question" },
+    { name: "Forum Answer" },
     { name: "Onboarding" },
     { name: "Uploads" },
   ],
@@ -444,6 +445,127 @@ export const openApiDoc = {
               },
             },
           },
+        },
+      },
+      CreateAnswerRequest: {
+        type: "object",
+        required: ["questionId", "body"],
+        properties: {
+          questionId: {
+            type: "string",
+            format: "uuid",
+            example: "f28e0170-a5b2-4e69-b4f8-e9dc450ab322",
+          },
+          body: {
+            type: "string",
+            minLength: 1,
+            maxLength: 10000,
+            example: "You can start with daily listening practice and short writing prompts.",
+          },
+        },
+      },
+      UpdateAnswerRequest: {
+        type: "object",
+        required: ["body"],
+        properties: {
+          body: {
+            type: "string",
+            minLength: 1,
+            maxLength: 10000,
+            example: "I updated this answer with clearer steps and resources.",
+          },
+        },
+      },
+      VoteAnswerRequest: {
+        type: "object",
+        required: ["voteType"],
+        properties: {
+          voteType: {
+            type: "string",
+            enum: ["UPVOTE", "DOWNVOTE", "NONE"],
+            example: "UPVOTE",
+            description:
+              "UPVOTE or DOWNVOTE sets the vote; NONE removes the current user's vote.",
+          },
+        },
+      },
+      ForumAnswer: {
+        type: "object",
+        required: [
+          "id",
+          "questionId",
+          "authorId",
+          "body",
+          "status",
+          "upvoteCount",
+          "downvoteCount",
+          "createdAt",
+          "updatedAt",
+          "deletedAt",
+        ],
+        properties: {
+          id: { type: "string", format: "uuid" },
+          questionId: { type: "string", format: "uuid" },
+          authorId: { type: "string", format: "uuid" },
+          body: { type: "string" },
+          status: { type: "string", enum: ["PUBLISHED", "DELETED"], example: "PUBLISHED" },
+          upvoteCount: { type: "integer", example: 12 },
+          downvoteCount: { type: "integer", example: 2 },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+          deletedAt: { type: "string", format: "date-time", nullable: true },
+        },
+      },
+      ForumAnswerWithViewerVote: {
+        allOf: [
+          { $ref: "#/components/schemas/ForumAnswer" },
+          {
+            type: "object",
+            required: ["score", "viewerVote"],
+            properties: {
+              score: { type: "integer", example: 10 },
+              viewerVote: {
+                type: "string",
+                enum: ["UPVOTE", "DOWNVOTE"],
+                nullable: true,
+                example: "UPVOTE",
+              },
+            },
+          },
+        ],
+      },
+      CreateAnswerSuccessResponse: {
+        type: "object",
+        required: ["ok", "answer"],
+        properties: {
+          ok: { type: "boolean", enum: [true], example: true },
+          answer: { $ref: "#/components/schemas/ForumAnswerWithViewerVote" },
+        },
+      },
+      GetAnswersSuccessResponse: {
+        type: "object",
+        required: ["ok", "answers"],
+        properties: {
+          ok: { type: "boolean", enum: [true], example: true },
+          answers: {
+            type: "array",
+            items: { $ref: "#/components/schemas/ForumAnswerWithViewerVote" },
+          },
+        },
+      },
+      VoteAnswerSuccessResponse: {
+        type: "object",
+        required: ["ok", "answer"],
+        properties: {
+          ok: { type: "boolean", enum: [true], example: true },
+          answer: { $ref: "#/components/schemas/ForumAnswerWithViewerVote" },
+        },
+      },
+      OkTrueResponse: {
+        type: "object",
+        required: ["ok"],
+        properties: {
+          ok: { type: "boolean", enum: [true], example: true },
         },
       },
       OnboardingProfileStepRequest: {
@@ -1499,6 +1621,468 @@ export const openApiDoc = {
             content: {
               "application/json": {
                 schema: { $ref: "#/components/schemas/OnboardingRequiredErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal server error",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                    { $ref: "#/components/schemas/InternalServerErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/forum/answer/get-answers/{questionId}": {
+      get: {
+        tags: ["Forum Answer"],
+        summary: "Get published answers by question id",
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          {
+            in: "path",
+            name: "questionId",
+            required: true,
+            description: "Question UUID",
+            schema: { type: "string", format: "uuid" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Answers found",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/GetAnswersSuccessResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "Validation failed or invalid authenticated user id type",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseValidationIssuesResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/SimpleErrorResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "403": {
+            description: "Onboarding required",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OnboardingRequiredErrorResponse" },
+              },
+            },
+          },
+          "404": {
+            description: "Question not found",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal server error",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                    { $ref: "#/components/schemas/InternalServerErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/forum/answer/create-answer": {
+      post: {
+        tags: ["Forum Answer"],
+        summary: "Create answer",
+        security: [{ BearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateAnswerRequest" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Answer created",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CreateAnswerSuccessResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "Validation failed or invalid authenticated user id type",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseValidationIssuesResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/SimpleErrorResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "403": {
+            description: "Onboarding required",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OnboardingRequiredErrorResponse" },
+              },
+            },
+          },
+          "404": {
+            description: "Question not found",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "409": {
+            description: "Answers can only be posted to published questions",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal server error",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                    { $ref: "#/components/schemas/InternalServerErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/forum/answer/edit-answer/{answerId}": {
+      patch: {
+        tags: ["Forum Answer"],
+        summary: "Edit your own answer",
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          {
+            in: "path",
+            name: "answerId",
+            required: true,
+            description: "Answer UUID",
+            schema: { type: "string", format: "uuid" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdateAnswerRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Answer updated",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CreateAnswerSuccessResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "Validation failed or invalid authenticated user id type",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseValidationIssuesResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/SimpleErrorResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "403": {
+            description: "Forbidden (not your answer) or onboarding required",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OnboardingRequiredErrorResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Answer not found",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "409": {
+            description: "Only published answers can be edited",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal server error",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                    { $ref: "#/components/schemas/InternalServerErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/forum/answer/delete-answer/{answerId}": {
+      delete: {
+        tags: ["Forum Answer"],
+        summary: "Delete your own answer",
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          {
+            in: "path",
+            name: "answerId",
+            required: true,
+            description: "Answer UUID",
+            schema: { type: "string", format: "uuid" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Answer deleted",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkTrueResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "Validation failed or invalid authenticated user id type",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseValidationIssuesResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/SimpleErrorResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "403": {
+            description: "Forbidden (not your answer) or onboarding required",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OnboardingRequiredErrorResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Answer not found",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "409": {
+            description: "Answer is already deleted",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal server error",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                    { $ref: "#/components/schemas/InternalServerErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/forum/answer/vote-answer/{answerId}": {
+      post: {
+        tags: ["Forum Answer"],
+        summary: "Vote answer (upvote/downvote/remove)",
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          {
+            in: "path",
+            name: "answerId",
+            required: true,
+            description: "Answer UUID",
+            schema: { type: "string", format: "uuid" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/VoteAnswerRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Vote applied",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/VoteAnswerSuccessResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "Validation failed or invalid authenticated user id type",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseValidationIssuesResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/SimpleErrorResponse" },
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+          "403": {
+            description: "Onboarding required",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OnboardingRequiredErrorResponse" },
+              },
+            },
+          },
+          "404": {
+            description: "Answer not found",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
+              },
+            },
+          },
+          "409": {
+            description: "Cannot vote your own answer or vote on deleted answer",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OkFalseErrorResponse" },
               },
             },
           },

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { communityForumAnswerFeature } from "../community/forum/answer";
 import { communityForumFeature } from "../community/forum/categories";
 import { communityForumQuestionFeature } from "../community/forum/questions";
 import authRoute from "../auth";
@@ -9,6 +10,7 @@ const routes = new Hono();
 
 routes.route("/forum/category", communityForumFeature);
 routes.route("/forum/question", communityForumQuestionFeature);
+routes.route("/forum/answer", communityForumAnswerFeature);
 routes.route("/auth", authRoute);
 routes.route("/onboarding", onboardingRoute);
 routes.route("/uploads", uploadRoute);


### PR DESCRIPTION
- Add handler functions for creating, editing, deleting, retrieving, and voting on answers.
- Create corresponding routes for answer operations in the API.
- Implement database queries for answer management, including soft deletion and voting logic.
- Define schemas and validators for answer-related data.
- Update OpenAPI documentation to include new answer endpoints and request/response schemas.
- Introduce constants for UUID validation and PostgreSQL foreign key violation.