### PR TITLE
feat: add getCategories endpoint and update OpenAPI documentation

### DIFF
--- a/src/community/forum/categories/handler.ts
+++ b/src/community/forum/categories/handler.ts
@@ -4,7 +4,17 @@ import {
 } from "../constants";
 import { getValidatedForumAuthUserId } from "../utils/auth";
 import { validateCreateCategoryInput, type CreateCategoryInput } from "./schema";
-import { createCategory, findCategoryByName } from "./query";
+import { createCategory, findCategoryByName, getCategories } from "./query";
+
+export async function handleGetCategories(c: Context) {
+  try {
+    const categories = await getCategories();
+    return c.json({ ok: true, categories }, 200);
+  } catch (err) {
+    console.error("Failed to get categories", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
+  }
+}
 
 export async function handleCreateCategory(c: Context) {
   const authResult = getValidatedForumAuthUserId(c);

--- a/src/community/forum/categories/index.ts
+++ b/src/community/forum/categories/index.ts
@@ -1,9 +1,11 @@
 // App Entry Point for Community Forum Feature
 
 import { Hono } from "hono";
-import { requireAdmin } from "../../../auth/middleware";
-import { handleCreateCategory } from "./handler";
+import { requireAdmin, requireAccessToken } from "../../../auth/middleware";
+import { handleCreateCategory, handleGetCategories } from "./handler";
+
 
 export const communityForumFeature = new Hono();
 
-communityForumFeature.post("/create-category", requireAdmin, handleCreateCategory);
+communityForumFeature.get("/", requireAccessToken, handleGetCategories);
+communityForumFeature.post("/", requireAdmin, handleCreateCategory);

--- a/src/community/forum/categories/query.ts
+++ b/src/community/forum/categories/query.ts
@@ -10,6 +10,10 @@ import type { CreateCategoryInput } from "./schema";
 type ForumCategoryRow = typeof forumCategory.$inferSelect;
 type ForumCategoryInsert = typeof forumCategory.$inferInsert;
 
+export async function getCategories(): Promise<ForumCategoryRow[]> {
+  return db.select().from(forumCategory).orderBy(forumCategory.displayOrder);
+}
+
 export async function findCategoryById(id: string): Promise<ForumCategoryRow | null> {
   const rows = await db.select().from(forumCategory).where(eq(forumCategory.id, id));
   return rows[0] ?? null;

--- a/src/community/forum/categories/query.ts
+++ b/src/community/forum/categories/query.ts
@@ -11,7 +11,11 @@ type ForumCategoryRow = typeof forumCategory.$inferSelect;
 type ForumCategoryInsert = typeof forumCategory.$inferInsert;
 
 export async function getCategories(): Promise<ForumCategoryRow[]> {
-  return db.select().from(forumCategory).orderBy(forumCategory.displayOrder);
+  return db
+    .select()
+    .from(forumCategory)
+    .where(eq(forumCategory.status, "ACTIVE"))
+    .orderBy(forumCategory.displayOrder);
 }
 
 export async function findCategoryById(id: string): Promise<ForumCategoryRow | null> {

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -302,6 +302,17 @@ export const openApiDoc = {
           archivedAt: { type: "string", format: "date-time", nullable: true },
         },
       },
+      GetCategoriesSuccessResponse: {
+        type: "object",
+        required: ["ok", "categories"],
+        properties: {
+          ok: { type: "boolean", enum: [true], example: true },
+          categories: {
+            type: "array",
+            items: { $ref: "#/components/schemas/ForumCategory" },
+          },
+        },
+      },
       CreateCategorySuccessResponse: {
         type: "object",
         required: ["ok", "category"],
@@ -1295,7 +1306,51 @@ export const openApiDoc = {
         },
       },
     },
-    "/api/forum/category/create-category": {
+    "/api/forum/category": {
+      get: {
+        tags: ["Forum Category"],
+        summary: "List categories",
+        security: [{ BearerAuth: [] }],
+        responses: {
+          "200": {
+            description: "Categories found",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/GetCategoriesSuccessResponse" },
+              },
+            },
+          },
+          "401": {
+            description: "Unauthorized",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SimpleErrorResponse" },
+              },
+            },
+          },
+          "403": {
+            description: "Onboarding required",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/OnboardingRequiredErrorResponse" },
+              },
+            },
+          },
+          "500": {
+            description: "Internal server error",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OkFalseErrorResponse" },
+                    { $ref: "#/components/schemas/InternalServerErrorResponse" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
       post: {
         tags: ["Forum Category"],
         summary: "Create category",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to list active forum categories.

* **API Changes**
  * Consolidated category routes under a single "/api/forum/category" path (GET for listing, POST for creation).
  * GET now requires an access token; POST remains admin-protected.

* **Documentation**
  * Updated OpenAPI docs with the new list-categories response schema and revised path entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->