### PR TITLE
feat: add point system and transaction management

### DIFF
--- a/drizzle/main/0008_exotic_gideon.sql
+++ b/drizzle/main/0008_exotic_gideon.sql
@@ -1,0 +1,44 @@
+CREATE TYPE "public"."point_systems_mode" AS ENUM('action', 'support');--> statement-breakpoint
+CREATE TYPE "public"."point_transactions_action_type" AS ENUM('purchase_tk_merch', 'purchase_marketplace', 'purchase_new_merchant_bonus', 'purchase_service', 'leave_review', 'merchant_verified', 'course_published', 'course_completed', 'resource_approved', 'forum_question_posted', 'forum_first_question_bonus', 'forum_participation', 'forum_helpful_answer', 'forum_best_answer', 'forum_answer_upvotes', 'forum_question_upvotes', 'volunteer_opportunity_posted', 'volunteer_registered', 'volunteer_mission_completed', 'volunteer_5star_bonus', 'launchpad_completion_proposer', 'launchpad_completion_participant', 'launchpad_project_validated_proposer', 'launchpad_project_validated_participant', 'mentorship_session_mentor', 'mentorship_session_mentee', 'mentorship_5star_bonus', 'mentorship_review_bonus', 'event_attended_khmer_talk', 'event_attended_networking', 'event_attended_discover', 'event_organised', 'event_organised_rating_bonus', 'khmer_talk_speaker', 'referral_active_member', 'welcome_profile_complete', 'tier_advancement_bonus', 'redemtion_deduction');--> statement-breakpoint
+CREATE TYPE "public"."point_transactions_mode" AS ENUM('action', 'support');--> statement-breakpoint
+CREATE TYPE "public"."point_transactions_pool" AS ENUM('active', 'legacy', 'tier');--> statement-breakpoint
+CREATE TABLE "point_systems" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"key" varchar NOT NULL,
+	"value" integer DEFAULT 0 NOT NULL,
+	"description" varchar,
+	"max_per_day" integer DEFAULT 1 NOT NULL,
+	"mode" "point_systems_mode" DEFAULT 'action' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "point_transactions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"action_type" "point_transactions_action_type" NOT NULL,
+	"points" integer NOT NULL,
+	"reference_type" varchar,
+	"reference_id" uuid,
+	"pool" "point_transactions_pool" DEFAULT 'active' NOT NULL,
+	"mode" "point_transactions_mode" DEFAULT 'action' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "tier_history" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"tier_id" uuid NOT NULL,
+	"achieved_at" timestamp DEFAULT now() NOT NULL,
+	"points_at_time" integer NOT NULL
+);
+--> statement-breakpoint
+DROP TABLE "user_point_ledger" CASCADE;--> statement-breakpoint
+ALTER TABLE "point_transactions" ADD CONSTRAINT "point_transactions_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tier_history" ADD CONSTRAINT "tier_history_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tier_history" ADD CONSTRAINT "tier_history_tier_id_tier_id_fk" FOREIGN KEY ("tier_id") REFERENCES "public"."tier"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "point_systems_key_unique_idx" ON "point_systems" USING btree ("key");--> statement-breakpoint
+CREATE INDEX "point_transactions_user_id_idx" ON "point_transactions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "tier_history_user_id_idx" ON "tier_history" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "tier_history_tier_id_idx" ON "tier_history" USING btree ("tier_id");

--- a/drizzle/main/meta/0008_snapshot.json
+++ b/drizzle/main/meta/0008_snapshot.json
@@ -1,0 +1,3689 @@
+{
+  "id": "d421d181-6ad0-4d38-830d-fbd20b69a274",
+  "prevId": "73d82668-995a-4625-8dc7-901b15b3da26",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "user_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "onboarding_step": {
+          "name": "onboarding_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.city": {
+      "name": "city",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'countriesnow'"
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "city_country_normalized_name_unique_idx": {
+          "name": "city_country_normalized_name_unique_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "city_country_id_id_unique_idx": {
+          "name": "city_country_id_id_unique_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "city_country_idx": {
+          "name": "city_country_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "city_name_idx": {
+          "name": "city_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "city_country_id_country_id_fk": {
+          "name": "city_country_id_country_id_fk",
+          "tableFrom": "city",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso2": {
+          "name": "iso2",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'countriesnow'"
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "country_normalized_name_unique_idx": {
+          "name": "country_normalized_name_unique_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_name_idx": {
+          "name": "country_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interest": {
+      "name": "interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interest_slug_unique_idx": {
+          "name": "interest_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interest_label_unique_idx": {
+          "name": "interest_label_unique_idx",
+          "columns": [
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interest_active_idx": {
+          "name": "interest_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tier": {
+      "name": "tier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_points": {
+          "name": "min_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tier_slug_unique_idx": {
+          "name": "tier_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tier_rank_order_unique_idx": {
+          "name": "tier_rank_order_unique_idx",
+          "columns": [
+            {
+              "expression": "rank_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tier_min_points_unique_idx": {
+          "name": "tier_min_points_unique_idx",
+          "columns": [
+            {
+              "expression": "min_points",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contribution_onboard": {
+      "name": "user_contribution_onboard",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_member": {
+          "name": "community_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "find_volunteers": {
+          "name": "find_volunteers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "launch_project": {
+          "name": "launch_project",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "organize_event": {
+          "name": "organize_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contribution_onboard_user_id_idx": {
+          "name": "user_contribution_onboard_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contribution_onboard_user_id_user_id_fk": {
+          "name": "user_contribution_onboard_user_id_user_id_fk",
+          "tableFrom": "user_contribution_onboard",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_id": {
+          "name": "interest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_at": {
+          "name": "selected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_interest_user_interest_unique_idx": {
+          "name": "user_interest_user_interest_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "interest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_interest_user_id_idx": {
+          "name": "user_interest_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_interest_interest_id_idx": {
+          "name": "user_interest_interest_id_idx",
+          "columns": [
+            {
+              "expression": "interest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_interest_interest_id_interest_id_fk": {
+          "name": "user_interest_interest_id_interest_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "interest",
+          "columnsFrom": [
+            "interest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_profile_user_id_unique_idx": {
+          "name": "user_profile_user_id_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_profile_country_id_idx": {
+          "name": "user_profile_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_profile_city_id_idx": {
+          "name": "user_profile_city_id_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profile_user_id_user_id_fk": {
+          "name": "user_profile_user_id_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_profile_country_id_country_id_fk": {
+          "name": "user_profile_country_id_country_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_profile_city_id_city_id_fk": {
+          "name": "user_profile_city_id_city_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "city",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_progress": {
+      "name": "user_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_points": {
+          "name": "total_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_tier_id": {
+          "name": "current_tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_progress_current_tier_id_idx": {
+          "name": "user_progress_current_tier_id_idx",
+          "columns": [
+            {
+              "expression": "current_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_progress_user_id_user_id_fk": {
+          "name": "user_progress_user_id_user_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_progress_current_tier_id_tier_id_fk": {
+          "name": "user_progress_current_tier_id_tier_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "tier",
+          "columnsFrom": [
+            "current_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_answer": {
+      "name": "forum_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "forum_answer_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLISHED'"
+        },
+        "upvote_count": {
+          "name": "upvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvote_count": {
+          "name": "downvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forum_answer_question_idx": {
+          "name": "forum_answer_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_author_idx": {
+          "name": "forum_answer_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_status_idx": {
+          "name": "forum_answer_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_created_idx": {
+          "name": "forum_answer_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_answer_question_id_forum_question_id_fk": {
+          "name": "forum_answer_question_id_forum_question_id_fk",
+          "tableFrom": "forum_answer",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_answer_author_id_user_id_fk": {
+          "name": "forum_answer_author_id_user_id_fk",
+          "tableFrom": "forum_answer",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_answer_vote": {
+      "name": "forum_answer_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "forum_answer_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_answer_vote_answer_voter_unique_idx": {
+          "name": "forum_answer_vote_answer_voter_unique_idx",
+          "columns": [
+            {
+              "expression": "answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_vote_answer_idx": {
+          "name": "forum_answer_vote_answer_idx",
+          "columns": [
+            {
+              "expression": "answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_vote_voter_idx": {
+          "name": "forum_answer_vote_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_vote_type_idx": {
+          "name": "forum_answer_vote_type_idx",
+          "columns": [
+            {
+              "expression": "vote_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_answer_vote_answer_id_forum_answer_id_fk": {
+          "name": "forum_answer_vote_answer_id_forum_answer_id_fk",
+          "tableFrom": "forum_answer_vote",
+          "tableTo": "forum_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_answer_vote_voter_id_user_id_fk": {
+          "name": "forum_answer_vote_voter_id_user_id_fk",
+          "tableFrom": "forum_answer_vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_category": {
+      "name": "forum_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "forum_category_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forum_category_slug_unique_idx": {
+          "name": "forum_category_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_category_name_unique_idx": {
+          "name": "forum_category_name_unique_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_category_status_idx": {
+          "name": "forum_category_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_category_order_idx": {
+          "name": "forum_category_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_question": {
+      "name": "forum_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "forum_question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLISHED'"
+        },
+        "answer_count": {
+          "name": "answer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upvote_count": {
+          "name": "upvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvote_count": {
+          "name": "downvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forum_question_category_idx": {
+          "name": "forum_question_category_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_author_idx": {
+          "name": "forum_question_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_status_idx": {
+          "name": "forum_question_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_created_idx": {
+          "name": "forum_question_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_question_category_id_forum_category_id_fk": {
+          "name": "forum_question_category_id_forum_category_id_fk",
+          "tableFrom": "forum_question",
+          "tableTo": "forum_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forum_question_author_id_user_id_fk": {
+          "name": "forum_question_author_id_user_id_fk",
+          "tableFrom": "forum_question",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_question_vote": {
+      "name": "forum_question_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "forum_question_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_question_vote_question_voter_unique_idx": {
+          "name": "forum_question_vote_question_voter_unique_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_vote_question_idx": {
+          "name": "forum_question_vote_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_vote_voter_idx": {
+          "name": "forum_question_vote_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_vote_type_idx": {
+          "name": "forum_question_vote_type_idx",
+          "columns": [
+            {
+              "expression": "vote_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_question_vote_question_id_forum_question_id_fk": {
+          "name": "forum_question_vote_question_id_forum_question_id_fk",
+          "tableFrom": "forum_question_vote",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_question_vote_voter_id_user_id_fk": {
+          "name": "forum_question_vote_voter_id_user_id_fk",
+          "tableFrom": "forum_question_vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_reporting": {
+      "name": "forum_reporting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forum_reporting_question_id_forum_question_id_fk": {
+          "name": "forum_reporting_question_id_forum_question_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_reporting_answer_id_forum_answer_id_fk": {
+          "name": "forum_reporting_answer_id_forum_answer_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "forum_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_reporting_type_id_forum_reporting_type_id_fk": {
+          "name": "forum_reporting_type_id_forum_reporting_type_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "forum_reporting_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forum_reporting_created_by_user_id_fk": {
+          "name": "forum_reporting_created_by_user_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_reporting_type": {
+      "name": "forum_reporting_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_reporting_type_type_unique_idx": {
+          "name": "forum_reporting_type_type_unique_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_question_tag": {
+      "name": "forum_question_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_question_tag_question_tag_unique_idx": {
+          "name": "forum_question_tag_question_tag_unique_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_tag_question_idx": {
+          "name": "forum_question_tag_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_tag_tag_question_idx": {
+          "name": "forum_question_tag_tag_question_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_question_tag_question_id_forum_question_id_fk": {
+          "name": "forum_question_tag_question_id_forum_question_id_fk",
+          "tableFrom": "forum_question_tag",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_question_tag_tag_id_forum_tag_id_fk": {
+          "name": "forum_question_tag_tag_id_forum_tag_id_fk",
+          "tableFrom": "forum_question_tag",
+          "tableTo": "forum_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_tag": {
+      "name": "forum_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_tag_normalized_name_unique_idx": {
+          "name": "forum_tag_normalized_name_unique_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_tag_name_idx": {
+          "name": "forum_tag_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_category": {
+      "name": "volunteer_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_key": {
+          "name": "icon_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "volunteer_category_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "volunteer_category_slug_unique_idx": {
+          "name": "volunteer_category_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_category_name_unique_idx": {
+          "name": "volunteer_category_name_unique_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_category_status_idx": {
+          "name": "volunteer_category_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_category_order_idx": {
+          "name": "volunteer_category_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_category_created_by_user_id_fk": {
+          "name": "volunteer_category_created_by_user_id_fk",
+          "tableFrom": "volunteer_category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_category_updated_by_user_id_fk": {
+          "name": "volunteer_category_updated_by_user_id_fk",
+          "tableFrom": "volunteer_category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_opportunity": {
+      "name": "volunteer_opportunity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_impact": {
+          "name": "community_impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_label": {
+          "name": "duration_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commitment_label": {
+          "name": "commitment_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_deadline": {
+          "name": "application_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_key": {
+          "name": "cover_image_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "contact_telegram_username": {
+          "name": "contact_telegram_username",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_website_url": {
+          "name": "contact_website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "volunteer_opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLISHED'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "volunteer_opportunity_category_idx": {
+          "name": "volunteer_opportunity_category_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_city_idx": {
+          "name": "volunteer_opportunity_city_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_status_idx": {
+          "name": "volunteer_opportunity_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_deadline_idx": {
+          "name": "volunteer_opportunity_deadline_idx",
+          "columns": [
+            {
+              "expression": "application_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_created_by_idx": {
+          "name": "volunteer_opportunity_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_opportunity_category_id_volunteer_category_id_fk": {
+          "name": "volunteer_opportunity_category_id_volunteer_category_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "volunteer_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_city_id_city_id_fk": {
+          "name": "volunteer_opportunity_city_id_city_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "city",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_created_by_user_id_fk": {
+          "name": "volunteer_opportunity_created_by_user_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_updated_by_user_id_fk": {
+          "name": "volunteer_opportunity_updated_by_user_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_role": {
+      "name": "volunteer_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commitment_label": {
+          "name": "commitment_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_role_opportunity_idx": {
+          "name": "volunteer_role_opportunity_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_role_order_idx": {
+          "name": "volunteer_role_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_role_opportunity_id_volunteer_opportunity_id_fk": {
+          "name": "volunteer_role_opportunity_id_volunteer_opportunity_id_fk",
+          "tableFrom": "volunteer_role",
+          "tableTo": "volunteer_opportunity",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_role_requirement": {
+      "name": "volunteer_role_requirement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_text": {
+          "name": "requirement_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_role_requirement_role_idx": {
+          "name": "volunteer_role_requirement_role_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_role_requirement_order_idx": {
+          "name": "volunteer_role_requirement_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_role_requirement_role_id_volunteer_role_id_fk": {
+          "name": "volunteer_role_requirement_role_id_volunteer_role_id_fk",
+          "tableFrom": "volunteer_role_requirement",
+          "tableTo": "volunteer_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_systems": {
+      "name": "point_systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_per_day": {
+          "name": "max_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mode": {
+          "name": "mode",
+          "type": "point_systems_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'action'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_systems_key_unique_idx": {
+          "name": "point_systems_key_unique_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_transactions": {
+      "name": "point_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "point_transactions_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool": {
+          "name": "pool",
+          "type": "point_transactions_pool",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "point_transactions_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'action'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_transactions_user_id_idx": {
+          "name": "point_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_transactions_user_id_user_id_fk": {
+          "name": "point_transactions_user_id_user_id_fk",
+          "tableFrom": "point_transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tier_history": {
+      "name": "tier_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "points_at_time": {
+          "name": "points_at_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tier_history_user_id_idx": {
+          "name": "tier_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tier_history_tier_id_idx": {
+          "name": "tier_history_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tier_history_user_id_user_id_fk": {
+          "name": "tier_history_user_id_user_id_fk",
+          "tableFrom": "tier_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tier_history_tier_id_tier_id_fk": {
+          "name": "tier_history_tier_id_tier_id_fk",
+          "tableFrom": "tier_history",
+          "tableTo": "tier",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_gender": {
+      "name": "user_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.forum_answer_status": {
+      "name": "forum_answer_status",
+      "schema": "public",
+      "values": [
+        "PUBLISHED",
+        "DELETED"
+      ]
+    },
+    "public.forum_answer_vote_type": {
+      "name": "forum_answer_vote_type",
+      "schema": "public",
+      "values": [
+        "UPVOTE",
+        "DOWNVOTE"
+      ]
+    },
+    "public.forum_category_status": {
+      "name": "forum_category_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED",
+        "HIDDEN"
+      ]
+    },
+    "public.forum_question_status": {
+      "name": "forum_question_status",
+      "schema": "public",
+      "values": [
+        "PUBLISHED",
+        "CLOSED",
+        "DELETED"
+      ]
+    },
+    "public.forum_question_vote_type": {
+      "name": "forum_question_vote_type",
+      "schema": "public",
+      "values": [
+        "UPVOTE",
+        "DOWNVOTE"
+      ]
+    },
+    "public.volunteer_category_status": {
+      "name": "volunteer_category_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED",
+        "HIDDEN"
+      ]
+    },
+    "public.volunteer_opportunity_status": {
+      "name": "volunteer_opportunity_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PUBLISHED",
+        "ARCHIVED",
+        "CLOSED"
+      ]
+    },
+    "public.point_systems_mode": {
+      "name": "point_systems_mode",
+      "schema": "public",
+      "values": [
+        "action",
+        "support"
+      ]
+    },
+    "public.point_transactions_action_type": {
+      "name": "point_transactions_action_type",
+      "schema": "public",
+      "values": [
+        "purchase_tk_merch",
+        "purchase_marketplace",
+        "purchase_new_merchant_bonus",
+        "purchase_service",
+        "leave_review",
+        "merchant_verified",
+        "course_published",
+        "course_completed",
+        "resource_approved",
+        "forum_question_posted",
+        "forum_first_question_bonus",
+        "forum_participation",
+        "forum_helpful_answer",
+        "forum_best_answer",
+        "forum_answer_upvotes",
+        "forum_question_upvotes",
+        "volunteer_opportunity_posted",
+        "volunteer_registered",
+        "volunteer_mission_completed",
+        "volunteer_5star_bonus",
+        "launchpad_completion_proposer",
+        "launchpad_completion_participant",
+        "launchpad_project_validated_proposer",
+        "launchpad_project_validated_participant",
+        "mentorship_session_mentor",
+        "mentorship_session_mentee",
+        "mentorship_5star_bonus",
+        "mentorship_review_bonus",
+        "event_attended_khmer_talk",
+        "event_attended_networking",
+        "event_attended_discover",
+        "event_organised",
+        "event_organised_rating_bonus",
+        "khmer_talk_speaker",
+        "referral_active_member",
+        "welcome_profile_complete",
+        "tier_advancement_bonus",
+        "redemtion_deduction"
+      ]
+    },
+    "public.point_transactions_mode": {
+      "name": "point_transactions_mode",
+      "schema": "public",
+      "values": [
+        "action",
+        "support"
+      ]
+    },
+    "public.point_transactions_pool": {
+      "name": "point_transactions_pool",
+      "schema": "public",
+      "values": [
+        "active",
+        "legacy",
+        "tier"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/main/meta/_journal.json
+++ b/drizzle/main/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1775822605946,
       "tag": "0007_lazy_lady_mastermind",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776435469401,
+      "tag": "0008_exotic_gideon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -4,3 +4,4 @@ export * from "./forum";
 export * from "./question_tags";
 export * from "./volunteer/volunteer-categories";
 export * from "./volunteer/volunteer-opportunities";
+export * from "./point_system/point-systems";

--- a/src/db/schema/onboarding.ts
+++ b/src/db/schema/onboarding.ts
@@ -19,7 +19,9 @@ export const country = pgTable(
     name: varchar("name", { length: 120 }).notNull(),
     normalizedName: varchar("normalized_name", { length: 120 }).notNull(),
     iso2: varchar("iso2", { length: 2 }),
-    provider: varchar("provider", { length: 40 }).default("countriesnow").notNull(),
+    provider: varchar("provider", { length: 40 })
+      .default("countriesnow")
+      .notNull(),
     providerRef: varchar("provider_ref", { length: 120 }),
     isActive: boolean("is_active").default(true).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -43,7 +45,9 @@ export const city = pgTable(
       .references(() => country.id, { onDelete: "cascade" }),
     name: varchar("name", { length: 120 }).notNull(),
     normalizedName: varchar("normalized_name", { length: 120 }).notNull(),
-    provider: varchar("provider", { length: 40 }).default("countriesnow").notNull(),
+    provider: varchar("provider", { length: 40 })
+      .default("countriesnow")
+      .notNull(),
     providerRef: varchar("provider_ref", { length: 120 }),
     isActive: boolean("is_active").default(true).notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -178,27 +182,6 @@ export const tier = pgTable(
   ],
 );
 
-export const userPointLedger = pgTable(
-  "user_point_ledger",
-  {
-    id: uuid("id").defaultRandom().primaryKey(),
-    userId: uuid("user_id")
-      .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
-    pointsDelta: integer("points_delta").notNull(),
-    actionType: varchar("action_type", { length: 80 }).notNull(),
-    eventKey: varchar("event_key", { length: 120 }),
-    referenceType: varchar("reference_type", { length: 80 }),
-    referenceId: varchar("reference_id", { length: 120 }),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-  },
-  (table) => [
-    uniqueIndex("user_point_ledger_event_key_unique_idx").on(table.eventKey),
-    index("user_point_ledger_user_id_idx").on(table.userId),
-    index("user_point_ledger_action_type_idx").on(table.actionType),
-  ],
-);
-
 export const userProgress = pgTable(
   "user_progress",
   {
@@ -215,7 +198,9 @@ export const userProgress = pgTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("user_progress_current_tier_id_idx").on(table.currentTierId)],
+  (table) => [
+    index("user_progress_current_tier_id_idx").on(table.currentTierId),
+  ],
 );
 
 export const countryRelations = relations(country, ({ many }) => ({
@@ -273,13 +258,6 @@ export const userContributionOnboardRelations = relations(
 
 export const tierRelations = relations(tier, ({ many }) => ({
   userProgressRows: many(userProgress),
-}));
-
-export const userPointLedgerRelations = relations(userPointLedger, ({ one }) => ({
-  user: one(user, {
-    fields: [userPointLedger.userId],
-    references: [user.id],
-  }),
 }));
 
 export const userProgressRelations = relations(userProgress, ({ one }) => ({

--- a/src/db/schema/point_system/point-systems.ts
+++ b/src/db/schema/point_system/point-systems.ts
@@ -1,0 +1,151 @@
+import {
+  pgTable,
+  uuid,
+  varchar,
+  timestamp,
+  integer,
+  pgEnum,
+  uniqueIndex,
+  index,
+} from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { user } from "../user";
+import { tier } from "../onboarding";
+
+export const pointTransactionsActionType = pgEnum(
+  "point_transactions_action_type",
+  [
+    "purchase_tk_merch",
+    "purchase_marketplace",
+    "purchase_new_merchant_bonus",
+    "purchase_service",
+    "leave_review",
+    "merchant_verified",
+    "course_published",
+    "course_completed",
+    "resource_approved",
+    "forum_question_posted",
+    "forum_first_question_bonus",
+    "forum_participation",
+    "forum_helpful_answer",
+    "forum_best_answer",
+    "forum_answer_upvotes",
+    "forum_question_upvotes",
+    "volunteer_opportunity_posted",
+    "volunteer_registered",
+    "volunteer_mission_completed",
+    "volunteer_5star_bonus",
+    "launchpad_completion_proposer",
+    "launchpad_completion_participant",
+    "launchpad_project_validated_proposer",
+    "launchpad_project_validated_participant",
+    "mentorship_session_mentor",
+    "mentorship_session_mentee",
+    "mentorship_5star_bonus",
+    "mentorship_review_bonus",
+    "event_attended_khmer_talk",
+    "event_attended_networking",
+    "event_attended_discover",
+    "event_organised",
+    "event_organised_rating_bonus",
+    "khmer_talk_speaker",
+    "referral_active_member",
+    "welcome_profile_complete",
+    "tier_advancement_bonus",
+    "redemtion_deduction",
+  ],
+);
+
+export const pointTransactionsPool = pgEnum("point_transactions_pool", [
+  "active",
+  "legacy",
+  "tier",
+]);
+
+export const pointTransactionsMode = pgEnum("point_transactions_mode", [
+  "action",
+  "support",
+]);
+
+export const pointSystemsMode = pgEnum("point_systems_mode", [
+  "action",
+  "support",
+]);
+
+export const pointSystems = pgTable(
+  "point_systems",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    key: varchar("key").notNull(),
+    value: integer("value").notNull().default(0),
+    description: varchar("description"),
+    maxPerDay: integer("max_per_day").notNull().default(1),
+    mode: pointSystemsMode("mode").notNull().default("action"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("point_systems_key_unique_idx").using("btree", table.key),
+  ],
+);
+
+export const pointTransactions = pgTable(
+  "point_transactions",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => user.id),
+    actionType: pointTransactionsActionType("action_type").notNull(),
+    points: integer("points").notNull(),
+    reference_type: varchar("reference_type"),
+    reference_id: uuid("reference_id"),
+    pool: pointTransactionsPool("pool").notNull().default("active"),
+    mode: pointTransactionsMode("mode").notNull().default("action"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("point_transactions_user_id_idx").using("btree", table.userId),
+  ],
+);
+
+export const tierHistory = pgTable(
+  "tier_history",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => user.id),
+    tierId: uuid("tier_id")
+      .notNull()
+      .references(() => tier.id),
+    achievedAt: timestamp("achieved_at").notNull().defaultNow(),
+    pointsAtTime: integer("points_at_time").notNull(),
+  },
+  (table) => [
+    index("tier_history_user_id_idx").using("btree", table.userId),
+    index("tier_history_tier_id_idx").using("btree", table.tierId),
+  ],
+);
+
+export const pointTransactionsRelations = relations(
+  pointTransactions,
+  ({ one }) => ({
+    user: one(user, {
+      fields: [pointTransactions.userId],
+      references: [user.id],
+    }),
+  }),
+);
+
+export const tierHistoryRelations = relations(tierHistory, ({ one }) => ({
+  user: one(user, {
+    fields: [tierHistory.userId],
+    references: [user.id],
+  }),
+  tier: one(tier, {
+    fields: [tierHistory.tierId],
+    references: [tier.id],
+  }),
+}));

--- a/src/db/seeds/index.ts
+++ b/src/db/seeds/index.ts
@@ -2,6 +2,7 @@ import { seedForumCategories } from "./forum-categories.seed";
 import { seedForumReportingTypes } from "./forum-reporting-type.seed";
 import { seedOnboardingLookups } from "./onboarding-lookups.seed";
 import { closeDb } from "../index";
+import { seedPointSystems } from "./point-systems.seed";
 
 async function main() {
   console.log("🚀 Starting seed...\n");
@@ -9,6 +10,7 @@ async function main() {
   await seedForumReportingTypes();
   await seedOnboardingLookups();
   await seedForumCategories();
+  await seedPointSystems();
 
   console.log("\n🎉 All seeds complete.");
   await closeDb();

--- a/src/db/seeds/onboarding-lookups.seed.ts
+++ b/src/db/seeds/onboarding-lookups.seed.ts
@@ -25,21 +25,36 @@ const TIER_SEED = [
     name: "Neary",
     rankOrder: 1,
     minPoints: 0,
-    description: "Starting tier.",
+    description: "The everyday Cambodian citizen - the foundation of community",
   },
   {
     slug: "yothea",
     name: "Yothea",
     rankOrder: 2,
-    minPoints: 200,
-    description: "Second tier.",
+    minPoints: 500,
+    description: "The Warrior - actively fighting for Cambodia's progress",
   },
   {
     slug: "reach",
     name: "Reach",
     rankOrder: 3,
-    minPoints: 600,
-    description: "Advanced tier.",
+    minPoints: 2000,
+    description: "The Noble - a community leader who guides others with wisdom",
+  },
+  {
+    slug: "preah",
+    name: "Preah",
+    rankOrder: 4,
+    minPoints: 5000,
+    description: "The Sacred One - embodies Khmer values at the highest level",
+  },
+  {
+    slug: "indra",
+    name: "Indra",
+    rankOrder: 5,
+    minPoints: 10000,
+    description:
+      "The Divine - king of gods in Khmer mythology; ultimate contribution",
   },
 ] satisfies Array<
   Pick<
@@ -92,9 +107,18 @@ export async function seedOnboardingLookups() {
     target: interest.slug,
   });
 
-  await db.insert(tier).values(TIER_SEED).onConflictDoNothing({
-    target: tier.slug,
-  });
+  await db
+    .insert(tier)
+    .values(TIER_SEED)
+    .onConflictDoUpdate({
+      target: tier.slug,
+      set: {
+        name: tier.name,
+        rankOrder: tier.rankOrder,
+        minPoints: tier.minPoints,
+        description: tier.description,
+      },
+    });
 
   await db.insert(country).values(CAMBODIA_COUNTRY_SEED).onConflictDoNothing({
     target: country.normalizedName,

--- a/src/db/seeds/point-systems.seed.ts
+++ b/src/db/seeds/point-systems.seed.ts
@@ -1,0 +1,285 @@
+import { pointSystems } from "../schema/point_system/point-systems";
+import { db } from "../index";
+
+const POINT_SYSTEMS_SEED = [
+  {
+    key: "purchase_tk_merch",
+    value: 10,
+    description: "Purchase TK merch",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "purchase_marketplace",
+    value: 5,
+    description: "Purchase marketplace product",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "purchase_new_merchant_bonus",
+    value: 10,
+    description: "New merchant bonus (first purchase per merchant)",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "purchase_service",
+    value: 10,
+    description: "Purchase service from Khmer provider",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "leave_review",
+    value: 2,
+    description: "Leave product review",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "merchant_verified",
+    value: 50,
+    description: "Merchant verification (one-time)",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "course_published",
+    value: 50,
+    description: "Publish a course",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "course_completed",
+    value: 20,
+    description: "Complete a course",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "resource_approved",
+    value: 25,
+    description: "Upload approved library resource",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "forum_question_posted",
+    value: 1,
+    description: "Post a forum question",
+    maxPerDay: 5,
+    mode: "action",
+  },
+  {
+    key: "forum_first_question_bonus",
+    value: 10,
+    description: "First forum question bonus (after first reply)",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "forum_participation",
+    value: 1,
+    description: "Forum first answer in thread",
+    maxPerDay: 30,
+    mode: "support",
+  },
+  {
+    key: "forum_helpful_answer",
+    value: 10,
+    description: "Forum answer marked Helpful",
+    maxPerDay: 30,
+    mode: "support",
+  },
+  {
+    key: "forum_best_answer",
+    value: 25,
+    description: "Forum answer marked Best Answer",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "forum_answer_upvotes",
+    value: 2,
+    description: "Answer receives 10 community upvotes (+per 10)",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "forum_question_upvotes",
+    value: 2,
+    description: "Question receives 10 community upvotes (+per 10)",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "volunteer_opportunity_posted",
+    value: 20,
+    description: "Post a volunteer opportunity",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "volunteer_registered",
+    value: 5,
+    description: "Register as a volunteer",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "volunteer_mission_completed",
+    value: 40,
+    description: "Complete a volunteer mission",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "volunteer_5star_bonus",
+    value: 10,
+    description: "Receive a 5-star rating as a volunteer",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "launchpad_completion_proposer",
+    value: 80,
+    description: "Complete a launchpad proposal",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "launchpad_completion_participant",
+    value: 40,
+    description: "Complete a launchpad proposal",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "launchpad_project_validated_proposer",
+    value: 20,
+    description: "Validate a launchpad project as a proposer",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "launchpad_project_validated_participant",
+    value: 10,
+    description: "Validate a launchpad project as a participant",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "mentorship_session_mentor",
+    value: 40,
+    description: "Mentor a session",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "mentorship_session_mentee",
+    value: 20,
+    description: "Attend a mentorship session as a mentee",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "mentorship_5star_bonus",
+    value: 10,
+    description: "Receive a 5-star rating as a mentor or mentee",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "mentorship_review_bonus",
+    value: 5,
+    description: "Receive a 5-star rating as a mentor or mentee",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "event_attended_khmer_talk",
+    value: 15,
+    description: "Attend a Khmer Talk event",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "event_attended_networking",
+    value: 10,
+    description: "Attend a networking event",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "event_attended_discover",
+    value: 12,
+    description: "Attend a Discover Khmer visit",
+    maxPerDay: 0,
+    mode: "support",
+  },
+  {
+    key: "event_organised",
+    value: 100,
+    description: "Organize an event successfully",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "event_organised_rating_bonus",
+    value: 25,
+    description: "Organize an event successfully",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "khmer_talk_speaker",
+    value: 50,
+    description: "Speak at an event",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "referral_active_member",
+    value: 30,
+    description: "Refer an active new member (completes onboarding)",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "welcome_profile_complete",
+    value: 50,
+    description: "Complete onboarding process",
+    maxPerDay: 0,
+    mode: "action",
+  },
+  {
+    key: "tier_advancement_bonus",
+    value: 100,
+    description: "3-tier system: Neary, Yothea, Reach",
+    maxPerDay: 0,
+    mode: "action",
+  },
+] satisfies Array<
+  Pick<
+    typeof pointSystems.$inferInsert,
+    "key" | "value" | "description" | "maxPerDay" | "mode"
+  >
+>;
+
+export async function seedPointSystems() {
+  for (const system of POINT_SYSTEMS_SEED) {
+    await db
+      .insert(pointSystems)
+      .values(system)
+      .onConflictDoUpdate({
+        target: pointSystems.key,
+        set: {
+          value: system.value,
+          description: system.description,
+          maxPerDay: system.maxPerDay,
+        },
+      });
+  }
+}

--- a/src/modules/forum/answers/answers.query.ts
+++ b/src/modules/forum/answers/answers.query.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, ne, sql } from "drizzle-orm";
 import { db } from "../../../db/index";
 import {
   forumAnswer,
@@ -27,7 +27,10 @@ type AnswerHydrationRow = {
   viewerVoteType: string | null;
 };
 type PublicAnswerHydrationRow = Omit<AnswerHydrationRow, "viewerVoteType">;
-type ForumAnswerWithViewerVote = Omit<ForumAnswerRow, "authorId" | "deletedAt"> & {
+type ForumAnswerWithViewerVote = Omit<
+  ForumAnswerRow,
+  "authorId" | "deletedAt"
+> & {
   score: number;
   viewerVote: AnswerVoteType | null;
   author: {
@@ -85,15 +88,15 @@ function buildPublicAnswersBaseQuery(executor: Pick<typeof db, "select">) {
     .leftJoin(userProfile, eq(userProfile.userId, user.id));
 }
 
-function hydrateAnswer(
-  row: AnswerHydrationRow,
-): ForumAnswerWithViewerVote {
+function hydrateAnswer(row: AnswerHydrationRow): ForumAnswerWithViewerVote {
   const { authorId, deletedAt: _deletedAt, ...answer } = row.answer;
 
   return {
     ...answer,
     score: answer.upvoteCount - answer.downvoteCount,
-    viewerVote: row.viewerVoteType ? (row.viewerVoteType as AnswerVoteType) : null,
+    viewerVote: row.viewerVoteType
+      ? (row.viewerVoteType as AnswerVoteType)
+      : null,
     author: {
       id: authorId,
       name: resolveAuthorName(row),

--- a/src/modules/forum/answers/answers.service.ts
+++ b/src/modules/forum/answers/answers.service.ts
@@ -19,6 +19,10 @@ import {
 } from "./answers.query";
 import { POSTGRES_FOREIGN_KEY_VIOLATION } from "../../../db/constants";
 import { getAuthUserId } from "../../../modules/auth/utils/get-auth";
+import {
+  awardForumParticipationPoints,
+  awardForumUpvotePoints,
+} from "../../points/points.service";
 
 export async function handleGetAnswers(
   c: Context,
@@ -88,6 +92,16 @@ export async function handleCreateAnswer(c: Context, data: CreateAnswerInput) {
     }
 
     const newAnswer = await createAnswer(data, authResult.userId);
+
+    // Award forum participation + first question bonus (handled by point service)
+    awardForumParticipationPoints({
+      answerAuthorId: authResult.userId,
+      answerId: newAnswer.id,
+      questionId: data.questionId,
+    }).catch((err) =>
+      console.error("Failed to award forum answer points", err),
+    );
+
     return c.json({ ok: true, answer: newAnswer }, 201);
   } catch (err) {
     const code = (err as { code?: string } | null)?.code;
@@ -214,6 +228,17 @@ export async function handleVoteAnswer(
     if (!votedAnswer) {
       return c.json({ ok: false, error: "Answer not found" }, 404);
     }
+
+    awardForumUpvotePoints({
+      voterId: authResult.userId,
+      contentAuthorId: existingAnswer.authorId,
+      contentId: params.answerId,
+      contentType: "forum_answer",
+      score: votedAnswer.score,
+      voteType: data.voteType,
+    }).catch((err) =>
+      console.error("Failed to award forum_answer_upvotes points", err),
+    );
 
     return c.json(
       {

--- a/src/modules/forum/questions/questions.service.ts
+++ b/src/modules/forum/questions/questions.service.ts
@@ -4,7 +4,6 @@ import {
   type EditQuestionInput,
   type GetTrendingTagsQuery,
   type GetQuestionsQuery,
-
   type QuestionIdParams,
   type VoteQuestionInput,
 } from "./questions.schema";
@@ -23,6 +22,10 @@ import {
 import { getAuthUserId } from "../../auth/utils/get-auth";
 import { POSTGRES_FOREIGN_KEY_VIOLATION } from "../../../db/constants";
 import { findCategoryById } from "../categories/categories.query";
+import {
+  awardPoints,
+  awardForumUpvotePoints,
+} from "../../points/points.service";
 
 export async function handleGetQuestions(
   c: Context,
@@ -144,6 +147,16 @@ export async function handleCreateQuestion(
     }
 
     const newQuestion = await createQuestion(data, authResult.userId);
+
+    awardPoints({
+      userId: authResult.userId,
+      actionKey: "forum_question_posted",
+      referenceType: "forum_question",
+      referenceId: newQuestion.id,
+    }).catch((err) =>
+      console.error("Failed to award points for question", err),
+    );
+
     return c.json({ ok: true, question: newQuestion }, 201);
   } catch (err) {
     const code = (err as { code?: string } | null)?.code;
@@ -294,6 +307,17 @@ export async function handleVoteQuestion(
     if (!votedQuestion) {
       return c.json({ ok: false, error: "Question not found" }, 404);
     }
+
+    awardForumUpvotePoints({
+      voterId: authResult.userId,
+      contentAuthorId: existingQuestion.authorId,
+      contentId: params.questionId,
+      contentType: "forum_question",
+      score: votedQuestion.score,
+      voteType: data.voteType,
+    }).catch((err) =>
+      console.error("Failed to award forum_upvote points", err),
+    );
 
     return c.json(
       {

--- a/src/modules/onboarding/onboarding.query.ts
+++ b/src/modules/onboarding/onboarding.query.ts
@@ -9,7 +9,6 @@ import {
   user,
   userContributionOnboard,
   userInterest,
-  userPointLedger,
   userProfile,
   userProgress,
 } from "../../db/schema";
@@ -455,18 +454,6 @@ export async function completeOnboarding(userId: string) {
           updatedAt: new Date(),
         },
       });
-
-    await tx
-      .insert(userPointLedger)
-      .values({
-        userId,
-        pointsDelta: 0,
-        actionType: "ONBOARDING_COMPLETED",
-        eventKey: `onboarding_completed:${userId}`,
-        referenceType: "onboarding",
-        referenceId: "step-4",
-      })
-      .onConflictDoNothing({ target: userPointLedger.eventKey });
 
     await tx
       .update(user)

--- a/src/modules/onboarding/onboarding.service.ts
+++ b/src/modules/onboarding/onboarding.service.ts
@@ -1,5 +1,6 @@
 import type { Context } from "hono";
 import { getAuthUserId } from "../auth/utils/get-auth";
+import { awardPoints } from "../points/points.service";
 import {
   ONBOARDING_CONTRIBUTIONS_STEP,
   ONBOARDING_INTERESTS_STEP,
@@ -244,6 +245,15 @@ export async function handleCompleteOnboarding(c: Context) {
   }
 
   await completeOnboarding(authResult.userId);
+
+  // Award welcome/onboarding points through the point system
+  awardPoints({
+    userId: authResult.userId,
+    actionKey: "welcome_profile_complete",
+    referenceType: "onboarding",
+    referenceId: "step-4",
+  }).catch((err) => console.error("Failed to award onboarding points", err));
+
   const state = await getOnboardingState(authResult.userId);
 
   return c.json({ ok: true, state });

--- a/src/modules/points/points.query.ts
+++ b/src/modules/points/points.query.ts
@@ -1,0 +1,140 @@
+import { and, desc, eq, gte, lte, ne, sql } from "drizzle-orm";
+import { db } from "../../db/index";
+import {
+  pointSystems,
+  pointTransactions,
+} from "../../db/schema/point_system/point-systems";
+import type { pointTransactionsActionType } from "../../db/schema/point_system/point-systems";
+import { userProgress, tier, forumQuestion } from "../../db/schema";
+import { tierHistory } from "../../db/schema/point_system/point-systems";
+
+type ActionType = (typeof pointTransactionsActionType.enumValues)[number];
+
+export async function getPointSystemByKey(key: string) {
+  const [row] = await db
+    .select()
+    .from(pointSystems)
+    .where(eq(pointSystems.key, key))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function countUserTransactionsToday(
+  userId: string,
+  actionType: ActionType,
+) {
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+
+  const [result] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(pointTransactions)
+    .where(
+      and(
+        eq(pointTransactions.userId, userId),
+        eq(pointTransactions.actionType, actionType),
+        gte(pointTransactions.createdAt, startOfDay),
+      ),
+    );
+  return result?.count ?? 0;
+}
+
+export async function insertPointTransaction(data: {
+  userId: string;
+  actionType: ActionType;
+  points: number;
+  referenceType?: string;
+  referenceId?: string;
+  pool?: "active" | "legacy" | "tier";
+  mode?: "action" | "support";
+}) {
+  return await db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(pointTransactions)
+      .values({
+        userId: data.userId,
+        actionType: data.actionType,
+        points: data.points,
+        reference_type: data.referenceType ?? null,
+        reference_id: data.referenceId ?? null,
+        pool: data.pool ?? "active",
+        mode: data.mode ?? "action",
+      })
+      .returning();
+
+    await tx
+      .insert(userProgress)
+      .values({
+        userId: data.userId,
+        totalPoints: data.points,
+      })
+      .onConflictDoUpdate({
+        target: userProgress.userId,
+        set: {
+          totalPoints: sql`${userProgress.totalPoints} + ${data.points}`,
+          updatedAt: new Date(),
+        },
+      });
+
+    const [progress] = await tx
+      .select({
+        totalPoints: userProgress.totalPoints,
+        currentTierId: userProgress.currentTierId,
+      })
+      .from(userProgress)
+      .where(eq(userProgress.userId, data.userId));
+
+    const [qualifiedTier] = await tx
+      .select({ id: tier.id })
+      .from(tier)
+      .where(lte(tier.minPoints, progress.totalPoints))
+      .orderBy(desc(tier.minPoints))
+      .limit(1);
+
+    if (qualifiedTier && qualifiedTier.id !== progress.currentTierId) {
+      await tx
+        .update(userProgress)
+        .set({
+          currentTierId: qualifiedTier.id,
+          updatedAt: new Date(),
+        })
+        .where(eq(userProgress.userId, data.userId));
+
+      await tx.insert(tierHistory).values({
+        userId: data.userId,
+        tierId: qualifiedTier.id,
+        pointsAtTime: progress.totalPoints,
+      });
+    }
+
+    return row;
+  });
+}
+
+/**
+ * Get a forum question by ID.
+ */
+export async function getForumQuestionById(questionId: string) {
+  const [row] = await db
+    .select()
+    .from(forumQuestion)
+    .where(eq(forumQuestion.id, questionId))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Count how many non-deleted questions a user has posted.
+ */
+export async function countUserForumQuestions(userId: string): Promise<number> {
+  const [result] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(forumQuestion)
+    .where(
+      and(
+        eq(forumQuestion.authorId, userId),
+        ne(forumQuestion.status, "DELETED"),
+      ),
+    );
+  return result?.count ?? 0;
+}

--- a/src/modules/points/points.service.ts
+++ b/src/modules/points/points.service.ts
@@ -1,0 +1,113 @@
+import {
+  getPointSystemByKey,
+  countUserTransactionsToday,
+  insertPointTransaction,
+  getForumQuestionById,
+  countUserForumQuestions,
+} from "./points.query";
+
+export async function awardPoints(params: {
+  userId: string;
+  actionKey: string;
+  referenceType?: string;
+  referenceId?: string;
+}) {
+  const config = await getPointSystemByKey(params.actionKey);
+  if (!config) {
+    console.warn(`Point system config not found for key: ${params.actionKey}`);
+    return null;
+  }
+
+  // Check daily limit (0 = unlimited)
+  if (config.maxPerDay > 0) {
+    const todayCount = await countUserTransactionsToday(
+      params.userId,
+      params.actionKey as any,
+    );
+    if (todayCount >= config.maxPerDay) {
+      return null;
+    }
+  }
+
+  const transaction = await insertPointTransaction({
+    userId: params.userId,
+    actionType: params.actionKey as any,
+    points: config.value,
+    referenceType: params.referenceType,
+    referenceId: params.referenceId,
+    mode: config.mode,
+  });
+
+  return transaction;
+}
+
+/**
+ * Award points for posting a forum answer.
+ * Also handles the first-question bonus: if the question author's
+ * first-ever question just received its first reply, award the bonus.
+ */
+export async function awardForumParticipationPoints(params: {
+  answerAuthorId: string;
+  answerId: string;
+  questionId: string;
+}) {
+  // Award participation points to the answer author
+  await awardPoints({
+    userId: params.answerAuthorId,
+    actionKey: "forum_participation",
+    referenceType: "forum_answer",
+    referenceId: params.answerId,
+  });
+
+  // Check first-question bonus for the question author
+  const question = await getForumQuestionById(params.questionId);
+  if (
+    question &&
+    question.authorId !== params.answerAuthorId &&
+    question.answerCount <= 1 // just got its first reply
+  ) {
+    const questionCount = await countUserForumQuestions(question.authorId);
+    if (questionCount === 1) {
+      await awardPoints({
+        userId: question.authorId,
+        actionKey: "forum_first_question_bonus",
+        referenceType: "forum_question",
+        referenceId: question.id,
+      });
+    }
+  }
+}
+
+/**
+ * Award upvote milestone points to content author.
+ * Awards points every time the score hits a multiple of 10.
+ */
+export async function awardForumUpvotePoints(params: {
+  voterId: string;
+  contentAuthorId: string;
+  contentId: string;
+  contentType: "forum_question" | "forum_answer";
+  score: number;
+  voteType: string;
+}) {
+  if (
+    params.voteType !== "UPVOTE" ||
+    params.contentAuthorId === params.voterId ||
+    params.score <= 0 ||
+    params.score % 10 !== 0
+  ) {
+    return null;
+  }
+
+  const actionKey =
+    params.contentType === "forum_question"
+      ? "forum_question_upvotes"
+      : "forum_answer_upvotes";
+
+  return awardPoints({
+    userId: params.contentAuthorId,
+    actionKey,
+    referenceType: params.contentType,
+    referenceId: params.contentId,
+  });
+}


### PR DESCRIPTION
- Introduced point systems with various actions and corresponding point values.
- Implemented point transaction logic to track user points based on actions.
- Award points for forum participation and upvotes, including bonuses for first replies.
- Updated onboarding process to award points upon completion.
- Refactored onboarding and forum services to integrate point awarding functionality.
- Added new seed data for point systems and updated existing onboarding lookups.
- Removed deprecated user point ledger schema and related logic.