### PR TITLE
feat: remove publicUrl from presignVolunteerCoverUpload and related s…

### DIFF
--- a/src/modules/uploads/types.ts
+++ b/src/modules/uploads/types.ts
@@ -18,7 +18,6 @@ export type PresignVolunteerCoverUploadResponse = {
     "Content-Type": string;
   };
   coverImageKey: string;
-  publicUrl: string | null;
   expiresInSeconds: number;
 };
 

--- a/src/modules/uploads/uploads.service.ts
+++ b/src/modules/uploads/uploads.service.ts
@@ -49,8 +49,12 @@ function buildAvatarKey(userId: string, fileName: string) {
   return buildNestedImageObjectKey("avatars", userId, fileName);
 }
 
-function buildVolunteerCoverKey(userId: string, fileName: string) {
-  return buildNestedImageObjectKey("volunteer-covers", userId, fileName);
+function buildVolunteerCoverKey(userId: string, contentType: string) {
+  return buildNestedImageObjectKeyFromContentType(
+    "volunteer-covers",
+    userId,
+    contentType,
+  );
 }
 
 function buildLaunchpadLogoKey(userId: string, contentType: string) {
@@ -225,13 +229,12 @@ export function resolveR2PublicUrl(objectKey: string) {
 
 export function presignVolunteerCoverUpload(options: {
   userId: string;
-  fileName: string;
   contentType: string;
   fileSize: number;
 }) {
   const coverImageKey = buildVolunteerCoverKey(
     options.userId,
-    options.fileName,
+    options.contentType,
   );
   const presigned = buildPresignedPutUrl(
     coverImageKey,
@@ -244,7 +247,6 @@ export function presignVolunteerCoverUpload(options: {
     method: "PUT",
     requiredHeaders: presigned.requiredHeaders,
     coverImageKey,
-    publicUrl: resolvePublicUrl(coverImageKey),
     expiresInSeconds: presigned.expiresInSeconds,
   };
 

--- a/src/modules/volunteer/post-volunteer/post-volunteer.query.ts
+++ b/src/modules/volunteer/post-volunteer/post-volunteer.query.ts
@@ -129,7 +129,7 @@ export type VolunteerOpportunityListItem = {
   applicationDeadline: string;
   applicationCount: number;
   capacity: number;
-  coverImageUrl: string | null;
+  coverImageKey: string;
   category: VolunteerReference;
   location: VolunteerReference;
 };
@@ -146,7 +146,6 @@ export type VolunteerOpportunityDetail = {
   applicationCount: number;
   capacity: number;
   coverImageKey: string;
-  coverImageUrl: string | null;
   benefits: string[];
   status: VolunteerOpportunityRow["status"];
   publishedAt: string | null;
@@ -392,7 +391,6 @@ export async function hasVolunteerApplicationForOpportunity(
 export type CreateVolunteerOpportunityInput =
   CreateVolunteerOpportunityBodyInput & {
     createdBy: string;
-    coverImageUrl: string | null;
     category: VolunteerReference;
     location: VolunteerReference;
   };
@@ -420,7 +418,7 @@ function hydrateVolunteerOpportunityListItem(
     applicationDeadline: row.opportunity.applicationDeadline,
     applicationCount: toInteger(row.applicationCount),
     capacity: toInteger(row.capacity),
-    coverImageUrl: row.opportunity.coverImageUrl,
+    coverImageKey: row.opportunity.coverImageKey,
     category: row.category,
     location: row.location,
   };
@@ -494,7 +492,6 @@ function hydrateVolunteerOpportunityDetail(
     applicationCount,
     capacity,
     coverImageKey: opportunity.coverImageKey,
-    coverImageUrl: opportunity.coverImageUrl,
     benefits: opportunity.benefits as string[],
     status: opportunity.status,
     publishedAt: opportunity.publishedAt,
@@ -985,7 +982,6 @@ export async function createVolunteerOpportunity(
         commitmentLabel: data.commitmentLabel,
         applicationDeadline: data.applicationDeadline,
         coverImageKey: data.coverImageKey,
-        coverImageUrl: data.coverImageUrl,
         benefits: data.benefits,
         contactEmail: data.contact.email,
         contactTelegramUsername: data.contact.telegramUsername,

--- a/src/modules/volunteer/post-volunteer/post-volunteer.service.ts
+++ b/src/modules/volunteer/post-volunteer/post-volunteer.service.ts
@@ -3,7 +3,6 @@ import { POSTGRES_UNIQUE_VIOLATION } from "../../../db/constants";
 import {
   presignVolunteerApplicationDocumentUpload,
   presignVolunteerCoverUpload,
-  resolveR2PublicUrl,
 } from "../../uploads/uploads.service";
 import { getAuthUserId } from "../../auth/utils/get-auth";
 import {
@@ -39,15 +38,10 @@ const VOLUNTEER_APPLICATION_APPLICANT_OPPORTUNITY_UNIQUE_INDEX =
 
 function sanitizePublicVolunteerOpportunity<
   T extends {
-    coverImageKey: string;
     createdBy: string;
   },
 >(opportunity: T) {
-  const {
-    coverImageKey: _coverImageKey,
-    createdBy: _createdBy,
-    ...publicOpportunity
-  } = opportunity;
+  const { createdBy: _createdBy, ...publicOpportunity } = opportunity;
 
   return publicOpportunity;
 }
@@ -480,7 +474,6 @@ export async function handleCreateVolunteerOpportunity(
       location,
       coverImageKey: normalizedCoverImageKey,
       createdBy: authResult.userId,
-      coverImageUrl: resolveR2PublicUrl(normalizedCoverImageKey),
     });
 
     return c.json({ ok: true, opportunity }, 201);

--- a/src/modules/volunteer/post-volunteer/post-volunteer.service.ts
+++ b/src/modules/volunteer/post-volunteer/post-volunteer.service.ts
@@ -284,7 +284,6 @@ export async function handlePresignVolunteerOpportunityCoverUpload(
   try {
     const upload = presignVolunteerCoverUpload({
       userId: authResult.userId,
-      fileName: payload.fileName,
       contentType: payload.contentType,
       fileSize: payload.fileSize,
     });

--- a/src/modules/volunteer/post-volunteer/schema/opportunities.request.schema.ts
+++ b/src/modules/volunteer/post-volunteer/schema/opportunities.request.schema.ts
@@ -7,7 +7,6 @@ const VOLUNTEER_COVER_IMAGE_ALLOWED_CONTENT_TYPES = [
   "image/webp",
 ] as const;
 const VOLUNTEER_APPLICATION_DOCUMENT_CONTENT_TYPE = "application/pdf";
-const SAFE_UPLOAD_FILE_NAME = /^[A-Za-z0-9._-]+$/;
 const MAX_VOLUNTEER_OPPORTUNITIES_PAGE_SIZE = 50;
 const DEFAULT_VOLUNTEER_OPPORTUNITIES_PAGE_SIZE = 10;
 const MIN_VOLUNTEER_APPLICATION_DOCUMENT_COUNT = 1;
@@ -244,12 +243,6 @@ const volunteerOpportunityRoleSchema = z
 
 export const presignVolunteerOpportunityCoverUploadSchema = z
   .object({
-    fileName: z
-      .string()
-      .trim()
-      .min(1, "fileName is required")
-      .max(120, "fileName must be <= 120 characters")
-      .regex(SAFE_UPLOAD_FILE_NAME, "fileName contains invalid characters"),
     contentType: z
       .string()
       .trim()

--- a/src/modules/volunteer/post-volunteer/schema/opportunities.response.schema.ts
+++ b/src/modules/volunteer/post-volunteer/schema/opportunities.response.schema.ts
@@ -11,7 +11,6 @@ export const presignVolunteerOpportunityCoverUploadResultSchema = z
     method: z.literal("PUT"),
     requiredHeaders: presignedUploadHeadersSchema,
     coverImageKey: z.string(),
-    publicUrl: z.string().nullable(),
     expiresInSeconds: z.number(),
   })
   .openapi("PresignVolunteerOpportunityCoverUploadResult");

--- a/src/modules/volunteer/post-volunteer/schema/opportunities.response.schema.ts
+++ b/src/modules/volunteer/post-volunteer/schema/opportunities.response.schema.ts
@@ -88,7 +88,7 @@ export const volunteerOpportunityListItemResponseSchema = z
     applicationDeadline: z.string(),
     applicationCount: z.number(),
     capacity: z.number(),
-    coverImageUrl: z.string().nullable(),
+    coverImageKey: z.string(),
     category: volunteerOpportunityReferenceSchema,
     location: volunteerOpportunityReferenceSchema,
   })
@@ -108,7 +108,6 @@ export const volunteerOpportunityResponseSchema = z
     applicationCount: z.number(),
     capacity: z.number(),
     coverImageKey: z.string(),
-    coverImageUrl: z.string().nullable(),
     benefits: z.array(z.string()),
     status: z.enum(["DRAFT", "PUBLISHED", "ARCHIVED", "CLOSED"]),
     publishedAt: z.string().nullable(),
@@ -123,7 +122,6 @@ export const volunteerOpportunityResponseSchema = z
 export const publicVolunteerOpportunityResponseSchema =
   volunteerOpportunityResponseSchema
     .omit({
-      coverImageKey: true,
       createdBy: true,
     })
     .openapi("PublicVolunteerOpportunityResponse");


### PR DESCRIPTION
…chemas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Volunteer cover upload presigning process updated: file uploads now identified by content type rather than file name
  * Public URL field removed from volunteer cover upload presigning response

<!-- end of auto-generated comment: release notes by coderabbit.ai -->