### PR TITLE
feat: add endpoint to retrieve saved items with pagination

### DIFF
--- a/drizzle/main/0046_lying_microchip.sql
+++ b/drizzle/main/0046_lying_microchip.sql
@@ -1,0 +1,6 @@
+DROP INDEX "forum_question_save_saver_idx";--> statement-breakpoint
+DROP INDEX "volunteer_opportunity_save_saver_idx";--> statement-breakpoint
+DROP INDEX "launchpad_save_saver_idx";--> statement-breakpoint
+CREATE INDEX "forum_question_save_saver_created_question_idx" ON "forum_question_save" USING btree ("saver_id","created_at","question_id");--> statement-breakpoint
+CREATE INDEX "volunteer_opportunity_save_saver_created_opportunity_idx" ON "volunteer_opportunity_save" USING btree ("saver_id","created_at","opportunity_id");--> statement-breakpoint
+CREATE INDEX "launchpad_save_saver_created_launchpad_idx" ON "launchpad_save" USING btree ("saver_id","created_at","launchpad_id");

--- a/drizzle/main/meta/0046_snapshot.json
+++ b/drizzle/main/meta/0046_snapshot.json
@@ -1,0 +1,6405 @@
+{
+  "id": "f2048c57-d6f9-492f-b9e1-90f6004cffee",
+  "prevId": "8acae9b1-b4ed-4baa-aee9-ea1b76598a18",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "user_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "onboarding_step": {
+          "name": "onboarding_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_normalized_name_unique_idx": {
+          "name": "skill_normalized_name_unique_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_name_idx": {
+          "name": "skill_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_skill": {
+      "name": "user_skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_skill_user_skill_unique_idx": {
+          "name": "user_skill_user_skill_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_skill_user_id_idx": {
+          "name": "user_skill_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_skill_skill_id_idx": {
+          "name": "user_skill_skill_id_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_skill_user_id_user_id_fk": {
+          "name": "user_skill_user_id_user_id_fk",
+          "tableFrom": "user_skill",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_skill_skill_id_skill_id_fk": {
+          "name": "user_skill_skill_id_skill_id_fk",
+          "tableFrom": "user_skill",
+          "tableTo": "skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_social_link": {
+      "name": "user_social_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "social_link_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_social_link_user_platform_unique_idx": {
+          "name": "user_social_link_user_platform_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_social_link_user_id_idx": {
+          "name": "user_social_link_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_social_link_user_id_user_id_fk": {
+          "name": "user_social_link_user_id_user_id_fk",
+          "tableFrom": "user_social_link",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.city": {
+      "name": "city",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'countriesnow'"
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "city_country_normalized_name_unique_idx": {
+          "name": "city_country_normalized_name_unique_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "city_country_id_id_unique_idx": {
+          "name": "city_country_id_id_unique_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "city_country_idx": {
+          "name": "city_country_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "city_name_idx": {
+          "name": "city_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "city_country_id_country_id_fk": {
+          "name": "city_country_id_country_id_fk",
+          "tableFrom": "city",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso2": {
+          "name": "iso2",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'countriesnow'"
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "country_normalized_name_unique_idx": {
+          "name": "country_normalized_name_unique_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_name_idx": {
+          "name": "country_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interest": {
+      "name": "interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interest_slug_unique_idx": {
+          "name": "interest_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interest_label_unique_idx": {
+          "name": "interest_label_unique_idx",
+          "columns": [
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interest_active_idx": {
+          "name": "interest_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tier": {
+      "name": "tier",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_points": {
+          "name": "min_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tier_slug_unique_idx": {
+          "name": "tier_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tier_rank_order_unique_idx": {
+          "name": "tier_rank_order_unique_idx",
+          "columns": [
+            {
+              "expression": "rank_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tier_min_points_unique_idx": {
+          "name": "tier_min_points_unique_idx",
+          "columns": [
+            {
+              "expression": "min_points",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contribution_onboard": {
+      "name": "user_contribution_onboard",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_member": {
+          "name": "community_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "find_volunteers": {
+          "name": "find_volunteers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "launch_project": {
+          "name": "launch_project",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "organize_event": {
+          "name": "organize_event",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_contribution_onboard_user_id_idx": {
+          "name": "user_contribution_onboard_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_contribution_onboard_user_id_user_id_fk": {
+          "name": "user_contribution_onboard_user_id_user_id_fk",
+          "tableFrom": "user_contribution_onboard",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest_id": {
+          "name": "interest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selected_at": {
+          "name": "selected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_interest_user_interest_unique_idx": {
+          "name": "user_interest_user_interest_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "interest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_interest_user_id_idx": {
+          "name": "user_interest_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_interest_interest_id_idx": {
+          "name": "user_interest_interest_id_idx",
+          "columns": [
+            {
+              "expression": "interest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_interest_interest_id_interest_id_fk": {
+          "name": "user_interest_interest_id_interest_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "interest",
+          "columnsFrom": [
+            "interest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profile": {
+      "name": "user_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_visibility": {
+          "name": "profile_visibility",
+          "type": "profile_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "contact_visibility": {
+          "name": "contact_visibility",
+          "type": "profile_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "social_links_visibility": {
+          "name": "social_links_visibility",
+          "type": "profile_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "contribution_visibility": {
+          "name": "contribution_visibility",
+          "type": "profile_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_profile_user_id_unique_idx": {
+          "name": "user_profile_user_id_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_profile_country_id_idx": {
+          "name": "user_profile_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_profile_city_id_idx": {
+          "name": "user_profile_city_id_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profile_user_id_user_id_fk": {
+          "name": "user_profile_user_id_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_profile_country_id_country_id_fk": {
+          "name": "user_profile_country_id_country_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_profile_city_id_city_id_fk": {
+          "name": "user_profile_city_id_city_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "city",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_progress": {
+      "name": "user_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_points": {
+          "name": "total_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_tier_id": {
+          "name": "current_tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_progress_current_tier_id_idx": {
+          "name": "user_progress_current_tier_id_idx",
+          "columns": [
+            {
+              "expression": "current_tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_progress_total_points_idx": {
+          "name": "user_progress_total_points_idx",
+          "columns": [
+            {
+              "expression": "total_points",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_progress_user_id_user_id_fk": {
+          "name": "user_progress_user_id_user_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_progress_current_tier_id_tier_id_fk": {
+          "name": "user_progress_current_tier_id_tier_id_fk",
+          "tableFrom": "user_progress",
+          "tableTo": "tier",
+          "columnsFrom": [
+            "current_tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_answer": {
+      "name": "forum_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "forum_answer_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLISHED'"
+        },
+        "upvote_count": {
+          "name": "upvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvote_count": {
+          "name": "downvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forum_answer_question_idx": {
+          "name": "forum_answer_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_author_idx": {
+          "name": "forum_answer_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_status_idx": {
+          "name": "forum_answer_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_created_idx": {
+          "name": "forum_answer_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_answer_question_id_forum_question_id_fk": {
+          "name": "forum_answer_question_id_forum_question_id_fk",
+          "tableFrom": "forum_answer",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_answer_author_id_user_id_fk": {
+          "name": "forum_answer_author_id_user_id_fk",
+          "tableFrom": "forum_answer",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forum_answer_reply_to_forum_answer_id_fk": {
+          "name": "forum_answer_reply_to_forum_answer_id_fk",
+          "tableFrom": "forum_answer",
+          "tableTo": "forum_answer",
+          "columnsFrom": [
+            "reply_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_answer_vote": {
+      "name": "forum_answer_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "forum_answer_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_answer_vote_answer_voter_unique_idx": {
+          "name": "forum_answer_vote_answer_voter_unique_idx",
+          "columns": [
+            {
+              "expression": "answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_vote_answer_idx": {
+          "name": "forum_answer_vote_answer_idx",
+          "columns": [
+            {
+              "expression": "answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_vote_voter_idx": {
+          "name": "forum_answer_vote_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_answer_vote_type_idx": {
+          "name": "forum_answer_vote_type_idx",
+          "columns": [
+            {
+              "expression": "vote_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_answer_vote_answer_id_forum_answer_id_fk": {
+          "name": "forum_answer_vote_answer_id_forum_answer_id_fk",
+          "tableFrom": "forum_answer_vote",
+          "tableTo": "forum_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_answer_vote_voter_id_user_id_fk": {
+          "name": "forum_answer_vote_voter_id_user_id_fk",
+          "tableFrom": "forum_answer_vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_category": {
+      "name": "forum_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "forum_category_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forum_category_slug_unique_idx": {
+          "name": "forum_category_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_category_name_unique_idx": {
+          "name": "forum_category_name_unique_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_category_status_idx": {
+          "name": "forum_category_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_category_order_idx": {
+          "name": "forum_category_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_question": {
+      "name": "forum_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "forum_question_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLISHED'"
+        },
+        "answer_count": {
+          "name": "answer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "upvote_count": {
+          "name": "upvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvote_count": {
+          "name": "downvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "best_answer_id": {
+          "name": "best_answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "best_answer_selected_at": {
+          "name": "best_answer_selected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forum_question_category_idx": {
+          "name": "forum_question_category_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_author_idx": {
+          "name": "forum_question_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_status_idx": {
+          "name": "forum_question_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_created_idx": {
+          "name": "forum_question_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_question_category_id_forum_category_id_fk": {
+          "name": "forum_question_category_id_forum_category_id_fk",
+          "tableFrom": "forum_question",
+          "tableTo": "forum_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forum_question_author_id_user_id_fk": {
+          "name": "forum_question_author_id_user_id_fk",
+          "tableFrom": "forum_question",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forum_question_best_answer_id_forum_answer_id_fk": {
+          "name": "forum_question_best_answer_id_forum_answer_id_fk",
+          "tableFrom": "forum_question",
+          "tableTo": "forum_answer",
+          "columnsFrom": [
+            "best_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_question_save": {
+      "name": "forum_question_save",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saver_id": {
+          "name": "saver_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_question_save_question_saver_unique_idx": {
+          "name": "forum_question_save_question_saver_unique_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "saver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_save_question_idx": {
+          "name": "forum_question_save_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_save_saver_created_question_idx": {
+          "name": "forum_question_save_saver_created_question_idx",
+          "columns": [
+            {
+              "expression": "saver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_question_save_question_id_forum_question_id_fk": {
+          "name": "forum_question_save_question_id_forum_question_id_fk",
+          "tableFrom": "forum_question_save",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_question_save_saver_id_user_id_fk": {
+          "name": "forum_question_save_saver_id_user_id_fk",
+          "tableFrom": "forum_question_save",
+          "tableTo": "user",
+          "columnsFrom": [
+            "saver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_question_vote": {
+      "name": "forum_question_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_id": {
+          "name": "voter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "forum_question_vote_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_question_vote_question_voter_unique_idx": {
+          "name": "forum_question_vote_question_voter_unique_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_vote_question_idx": {
+          "name": "forum_question_vote_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_vote_voter_idx": {
+          "name": "forum_question_vote_voter_idx",
+          "columns": [
+            {
+              "expression": "voter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_vote_type_idx": {
+          "name": "forum_question_vote_type_idx",
+          "columns": [
+            {
+              "expression": "vote_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_question_vote_question_id_forum_question_id_fk": {
+          "name": "forum_question_vote_question_id_forum_question_id_fk",
+          "tableFrom": "forum_question_vote",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_question_vote_voter_id_user_id_fk": {
+          "name": "forum_question_vote_voter_id_user_id_fk",
+          "tableFrom": "forum_question_vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "voter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_reporting": {
+      "name": "forum_reporting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_id": {
+          "name": "answer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forum_reporting_question_id_forum_question_id_fk": {
+          "name": "forum_reporting_question_id_forum_question_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_reporting_answer_id_forum_answer_id_fk": {
+          "name": "forum_reporting_answer_id_forum_answer_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "forum_answer",
+          "columnsFrom": [
+            "answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_reporting_type_id_forum_reporting_type_id_fk": {
+          "name": "forum_reporting_type_id_forum_reporting_type_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "forum_reporting_type",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forum_reporting_created_by_user_id_fk": {
+          "name": "forum_reporting_created_by_user_id_fk",
+          "tableFrom": "forum_reporting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_reporting_type": {
+      "name": "forum_reporting_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_reporting_type_type_unique_idx": {
+          "name": "forum_reporting_type_type_unique_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_question_tag": {
+      "name": "forum_question_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_question_tag_question_tag_unique_idx": {
+          "name": "forum_question_tag_question_tag_unique_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_tag_question_idx": {
+          "name": "forum_question_tag_question_idx",
+          "columns": [
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_question_tag_tag_question_idx": {
+          "name": "forum_question_tag_tag_question_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forum_question_tag_question_id_forum_question_id_fk": {
+          "name": "forum_question_tag_question_id_forum_question_id_fk",
+          "tableFrom": "forum_question_tag",
+          "tableTo": "forum_question",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "forum_question_tag_tag_id_forum_tag_id_fk": {
+          "name": "forum_question_tag_tag_id_forum_tag_id_fk",
+          "tableFrom": "forum_question_tag",
+          "tableTo": "forum_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forum_tag": {
+      "name": "forum_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forum_tag_normalized_name_unique_idx": {
+          "name": "forum_tag_normalized_name_unique_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forum_tag_name_idx": {
+          "name": "forum_tag_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_category": {
+      "name": "volunteer_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_key": {
+          "name": "icon_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "volunteer_category_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "volunteer_category_slug_unique_idx": {
+          "name": "volunteer_category_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_category_name_unique_idx": {
+          "name": "volunteer_category_name_unique_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_category_status_idx": {
+          "name": "volunteer_category_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_category_order_idx": {
+          "name": "volunteer_category_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_category_created_by_user_id_fk": {
+          "name": "volunteer_category_created_by_user_id_fk",
+          "tableFrom": "volunteer_category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_category_updated_by_user_id_fk": {
+          "name": "volunteer_category_updated_by_user_id_fk",
+          "tableFrom": "volunteer_category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_application": {
+      "name": "volunteer_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_id": {
+          "name": "applicant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "availability": {
+          "name": "availability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevant_experience": {
+          "name": "relevant_experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supporting_documents": {
+          "name": "supporting_documents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "top_pick": {
+          "name": "top_pick",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "volunteer_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_application_applicant_role_active_unique_idx": {
+          "name": "volunteer_application_applicant_role_active_unique_idx",
+          "columns": [
+            {
+              "expression": "applicant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"volunteer_application\".\"status\" in ('SUBMITTED', 'UNDER_REVIEW', 'APPROVED', 'CONFIRMED', 'COMPLETED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_application_applicant_opportunity_top_pick_active_unique_idx": {
+          "name": "volunteer_application_applicant_opportunity_top_pick_active_unique_idx",
+          "columns": [
+            {
+              "expression": "applicant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"volunteer_application\".\"top_pick\" = true and \"volunteer_application\".\"status\" in ('SUBMITTED', 'UNDER_REVIEW', 'APPROVED', 'CONFIRMED', 'COMPLETED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_application_opportunity_idx": {
+          "name": "volunteer_application_opportunity_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_application_opportunity_status_idx": {
+          "name": "volunteer_application_opportunity_status_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_application_role_idx": {
+          "name": "volunteer_application_role_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_application_applicant_idx": {
+          "name": "volunteer_application_applicant_idx",
+          "columns": [
+            {
+              "expression": "applicant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_application_status_idx": {
+          "name": "volunteer_application_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_application_opportunity_id_volunteer_opportunity_id_fk": {
+          "name": "volunteer_application_opportunity_id_volunteer_opportunity_id_fk",
+          "tableFrom": "volunteer_application",
+          "tableTo": "volunteer_opportunity",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volunteer_application_role_id_volunteer_role_id_fk": {
+          "name": "volunteer_application_role_id_volunteer_role_id_fk",
+          "tableFrom": "volunteer_application",
+          "tableTo": "volunteer_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volunteer_application_applicant_id_user_id_fk": {
+          "name": "volunteer_application_applicant_id_user_id_fk",
+          "tableFrom": "volunteer_application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "applicant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volunteer_application_role_opportunity_match_fk": {
+          "name": "volunteer_application_role_opportunity_match_fk",
+          "tableFrom": "volunteer_application",
+          "tableTo": "volunteer_role",
+          "columnsFrom": [
+            "role_id",
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id",
+            "opportunity_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "volunteer_application_supporting_documents_array_check": {
+          "name": "volunteer_application_supporting_documents_array_check",
+          "value": "jsonb_typeof(\"volunteer_application\".\"supporting_documents\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.volunteer_application_log": {
+      "name": "volunteer_application_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "volunteer_application_id": {
+          "name": "volunteer_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "volunteer_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "declined_by": {
+          "name": "declined_by",
+          "type": "application_declined_by",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_application_log_application_id_idx": {
+          "name": "volunteer_application_log_application_id_idx",
+          "columns": [
+            {
+              "expression": "volunteer_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_application_log_created_by_idx": {
+          "name": "volunteer_application_log_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_application_log_volunteer_application_id_volunteer_application_id_fk": {
+          "name": "volunteer_application_log_volunteer_application_id_volunteer_application_id_fk",
+          "tableFrom": "volunteer_application_log",
+          "tableTo": "volunteer_application",
+          "columnsFrom": [
+            "volunteer_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volunteer_application_log_created_by_user_id_fk": {
+          "name": "volunteer_application_log_created_by_user_id_fk",
+          "tableFrom": "volunteer_application_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_opportunity": {
+      "name": "volunteer_opportunity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_impact": {
+          "name": "community_impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_label": {
+          "name": "commitment_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commitment_description": {
+          "name": "commitment_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_deadline": {
+          "name": "application_deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_key": {
+          "name": "cover_image_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "contact_telegram_username": {
+          "name": "contact_telegram_username",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_website_url": {
+          "name": "contact_website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_view": {
+          "name": "total_view",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "filled": {
+          "name": "filled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "volunteer_opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LIVE'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "volunteer_opportunity_category_idx": {
+          "name": "volunteer_opportunity_category_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_city_idx": {
+          "name": "volunteer_opportunity_city_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_status_idx": {
+          "name": "volunteer_opportunity_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_deadline_idx": {
+          "name": "volunteer_opportunity_deadline_idx",
+          "columns": [
+            {
+              "expression": "application_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_created_by_idx": {
+          "name": "volunteer_opportunity_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_deleted_at_idx": {
+          "name": "volunteer_opportunity_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_opportunity_category_id_volunteer_category_id_fk": {
+          "name": "volunteer_opportunity_category_id_volunteer_category_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "volunteer_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_city_id_city_id_fk": {
+          "name": "volunteer_opportunity_city_id_city_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "city",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_created_by_user_id_fk": {
+          "name": "volunteer_opportunity_created_by_user_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_updated_by_user_id_fk": {
+          "name": "volunteer_opportunity_updated_by_user_id_fk",
+          "tableFrom": "volunteer_opportunity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_opportunity_action_log": {
+      "name": "volunteer_opportunity_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_data": {
+          "name": "from_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "to_data": {
+          "name": "to_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "volunteer_opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_opportunity_action_log_opportunity_idx": {
+          "name": "volunteer_opportunity_action_log_opportunity_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_action_log_created_by_idx": {
+          "name": "volunteer_opportunity_action_log_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_opportunity_action_log_opportunity_id_volunteer_opportunity_id_fk": {
+          "name": "volunteer_opportunity_action_log_opportunity_id_volunteer_opportunity_id_fk",
+          "tableFrom": "volunteer_opportunity_action_log",
+          "tableTo": "volunteer_opportunity",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_action_log_created_by_user_id_fk": {
+          "name": "volunteer_opportunity_action_log_created_by_user_id_fk",
+          "tableFrom": "volunteer_opportunity_action_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_opportunity_save": {
+      "name": "volunteer_opportunity_save",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saver_id": {
+          "name": "saver_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_opportunity_save_opportunity_saver_unique_idx": {
+          "name": "volunteer_opportunity_save_opportunity_saver_unique_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "saver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_save_opportunity_idx": {
+          "name": "volunteer_opportunity_save_opportunity_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_opportunity_save_saver_created_opportunity_idx": {
+          "name": "volunteer_opportunity_save_saver_created_opportunity_idx",
+          "columns": [
+            {
+              "expression": "saver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_opportunity_save_opportunity_id_volunteer_opportunity_id_fk": {
+          "name": "volunteer_opportunity_save_opportunity_id_volunteer_opportunity_id_fk",
+          "tableFrom": "volunteer_opportunity_save",
+          "tableTo": "volunteer_opportunity",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volunteer_opportunity_save_saver_id_user_id_fk": {
+          "name": "volunteer_opportunity_save_saver_id_user_id_fk",
+          "tableFrom": "volunteer_opportunity_save",
+          "tableTo": "user",
+          "columnsFrom": [
+            "saver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_role": {
+      "name": "volunteer_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commitment_label": {
+          "name": "commitment_label",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_role_id_opportunity_unique_idx": {
+          "name": "volunteer_role_id_opportunity_unique_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_role_opportunity_idx": {
+          "name": "volunteer_role_opportunity_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_role_order_idx": {
+          "name": "volunteer_role_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_role_opportunity_id_volunteer_opportunity_id_fk": {
+          "name": "volunteer_role_opportunity_id_volunteer_opportunity_id_fk",
+          "tableFrom": "volunteer_role",
+          "tableTo": "volunteer_opportunity",
+          "columnsFrom": [
+            "opportunity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volunteer_role_requirement": {
+      "name": "volunteer_role_requirement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_text": {
+          "name": "requirement_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volunteer_role_requirement_role_idx": {
+          "name": "volunteer_role_requirement_role_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volunteer_role_requirement_order_idx": {
+          "name": "volunteer_role_requirement_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volunteer_role_requirement_role_id_volunteer_role_id_fk": {
+          "name": "volunteer_role_requirement_role_id_volunteer_role_id_fk",
+          "tableFrom": "volunteer_role_requirement",
+          "tableTo": "volunteer_role",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_systems": {
+      "name": "point_systems",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_per_day": {
+          "name": "max_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "mode": {
+          "name": "mode",
+          "type": "point_systems_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'action'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_systems_key_unique_idx": {
+          "name": "point_systems_key_unique_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_transactions": {
+      "name": "point_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "point_transactions_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pool": {
+          "name": "pool",
+          "type": "point_transactions_pool",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "point_transactions_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'action'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_transactions_user_id_idx": {
+          "name": "point_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_transactions_user_id_user_id_fk": {
+          "name": "point_transactions_user_id_user_id_fk",
+          "tableFrom": "point_transactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tier_history": {
+      "name": "tier_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achieved_at": {
+          "name": "achieved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "points_at_time": {
+          "name": "points_at_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tier_history_user_id_idx": {
+          "name": "tier_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tier_history_tier_id_idx": {
+          "name": "tier_history_tier_id_idx",
+          "columns": [
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tier_history_user_tier_unique_idx": {
+          "name": "tier_history_user_tier_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tier_history_user_id_user_id_fk": {
+          "name": "tier_history_user_id_user_id_fk",
+          "tableFrom": "tier_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tier_history_tier_id_tier_id_fk": {
+          "name": "tier_history_tier_id_tier_id_fk",
+          "tableFrom": "tier_history",
+          "tableTo": "tier",
+          "columnsFrom": [
+            "tier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.launchpad_category": {
+      "name": "launchpad_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_key": {
+          "name": "icon_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "launchpad_category_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "total_launchpad": {
+          "name": "total_launchpad",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "launchpad_category_slug_unique_idx": {
+          "name": "launchpad_category_slug_unique_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_category_name_unique_idx": {
+          "name": "launchpad_category_name_unique_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_category_status_idx": {
+          "name": "launchpad_category_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_category_order_idx": {
+          "name": "launchpad_category_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.launchpad_role": {
+      "name": "launchpad_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "launchpad_id": {
+          "name": "launchpad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "launchpad_role_title_unique_idx": {
+          "name": "launchpad_role_title_unique_idx",
+          "columns": [
+            {
+              "expression": "launchpad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"title\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "launchpad_role_launchpad_id_launchpad_id_fk": {
+          "name": "launchpad_role_launchpad_id_launchpad_id_fk",
+          "tableFrom": "launchpad_role",
+          "tableTo": "launchpad",
+          "columnsFrom": [
+            "launchpad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "launchpad_role_created_by_user_id_fk": {
+          "name": "launchpad_role_created_by_user_id_fk",
+          "tableFrom": "launchpad_role",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "launchpad_role_updated_by_user_id_fk": {
+          "name": "launchpad_role_updated_by_user_id_fk",
+          "tableFrom": "launchpad_role",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.launchpad": {
+      "name": "launchpad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_key": {
+          "name": "logo_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_key": {
+          "name": "cover_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_keys": {
+          "name": "document_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "document_names": {
+          "name": "document_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_username": {
+          "name": "telegram_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_view": {
+          "name": "total_view",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "launchpad_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'LIVE'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "launchpad_category_id_idx": {
+          "name": "launchpad_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_city_id_idx": {
+          "name": "launchpad_city_id_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_status_idx": {
+          "name": "launchpad_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_deleted_at_idx": {
+          "name": "launchpad_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "launchpad_category_id_launchpad_category_id_fk": {
+          "name": "launchpad_category_id_launchpad_category_id_fk",
+          "tableFrom": "launchpad",
+          "tableTo": "launchpad_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "launchpad_city_id_city_id_fk": {
+          "name": "launchpad_city_id_city_id_fk",
+          "tableFrom": "launchpad",
+          "tableTo": "city",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "launchpad_created_by_user_id_fk": {
+          "name": "launchpad_created_by_user_id_fk",
+          "tableFrom": "launchpad",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "launchpad_updated_by_user_id_fk": {
+          "name": "launchpad_updated_by_user_id_fk",
+          "tableFrom": "launchpad",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.launchpad_action_log": {
+      "name": "launchpad_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "launchpad_id": {
+          "name": "launchpad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_data": {
+          "name": "from_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "to_data": {
+          "name": "to_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "launchpad_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "launchpad_action_log_launchpad_idx": {
+          "name": "launchpad_action_log_launchpad_idx",
+          "columns": [
+            {
+              "expression": "launchpad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_action_log_created_by_idx": {
+          "name": "launchpad_action_log_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "launchpad_action_log_launchpad_id_launchpad_id_fk": {
+          "name": "launchpad_action_log_launchpad_id_launchpad_id_fk",
+          "tableFrom": "launchpad_action_log",
+          "tableTo": "launchpad",
+          "columnsFrom": [
+            "launchpad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "launchpad_action_log_created_by_user_id_fk": {
+          "name": "launchpad_action_log_created_by_user_id_fk",
+          "tableFrom": "launchpad_action_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.launchpad_save": {
+      "name": "launchpad_save",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "launchpad_id": {
+          "name": "launchpad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saver_id": {
+          "name": "saver_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "launchpad_save_launchpad_saver_unique_idx": {
+          "name": "launchpad_save_launchpad_saver_unique_idx",
+          "columns": [
+            {
+              "expression": "launchpad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "saver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_save_launchpad_idx": {
+          "name": "launchpad_save_launchpad_idx",
+          "columns": [
+            {
+              "expression": "launchpad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_save_saver_created_launchpad_idx": {
+          "name": "launchpad_save_saver_created_launchpad_idx",
+          "columns": [
+            {
+              "expression": "saver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "launchpad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "launchpad_save_launchpad_id_launchpad_id_fk": {
+          "name": "launchpad_save_launchpad_id_launchpad_id_fk",
+          "tableFrom": "launchpad_save",
+          "tableTo": "launchpad",
+          "columnsFrom": [
+            "launchpad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "launchpad_save_saver_id_user_id_fk": {
+          "name": "launchpad_save_saver_id_user_id_fk",
+          "tableFrom": "launchpad_save",
+          "tableTo": "user",
+          "columnsFrom": [
+            "saver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recent_activity": {
+      "name": "recent_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recent_activity_user_created_idx": {
+          "name": "recent_activity_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recent_activity_type_idx": {
+          "name": "recent_activity_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recent_activity_target_idx": {
+          "name": "recent_activity_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recent_activity_reference_idx": {
+          "name": "recent_activity_reference_idx",
+          "columns": [
+            {
+              "expression": "reference_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recent_activity_user_reference_type_unique_idx": {
+          "name": "recent_activity_user_reference_type_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recent_activity_user_id_user_id_fk": {
+          "name": "recent_activity_user_id_user_id_fk",
+          "tableFrom": "recent_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.launchpad_application": {
+      "name": "launchpad_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "launchpad_id": {
+          "name": "launchpad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launchpad_role_id": {
+          "name": "launchpad_role_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevant_experience": {
+          "name": "relevant_experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "portfolio": {
+          "name": "portfolio",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_pick": {
+          "name": "top_pick",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "launchpad_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "document_keys": {
+          "name": "document_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "document_names": {
+          "name": "document_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "launchpad_application_launchpad_id_idx": {
+          "name": "launchpad_application_launchpad_id_idx",
+          "columns": [
+            {
+              "expression": "launchpad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_application_launchpad_role_id_idx": {
+          "name": "launchpad_application_launchpad_role_id_idx",
+          "columns": [
+            {
+              "expression": "launchpad_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_application_created_by_idx": {
+          "name": "launchpad_application_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_application_created_by_launchpad_top_pick_active_unique_idx": {
+          "name": "launchpad_application_created_by_launchpad_top_pick_active_unique_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "launchpad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"launchpad_application\".\"top_pick\" = true and \"launchpad_application\".\"status\" in ('SUBMITTED', 'UNDER_REVIEW', 'APPROVED', 'CONFIRMED', 'COMPLETED')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "launchpad_application_launchpad_id_launchpad_id_fk": {
+          "name": "launchpad_application_launchpad_id_launchpad_id_fk",
+          "tableFrom": "launchpad_application",
+          "tableTo": "launchpad",
+          "columnsFrom": [
+            "launchpad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "launchpad_application_launchpad_role_id_launchpad_role_id_fk": {
+          "name": "launchpad_application_launchpad_role_id_launchpad_role_id_fk",
+          "tableFrom": "launchpad_application",
+          "tableTo": "launchpad_role",
+          "columnsFrom": [
+            "launchpad_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "launchpad_application_created_by_user_id_fk": {
+          "name": "launchpad_application_created_by_user_id_fk",
+          "tableFrom": "launchpad_application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.launchpad_application_log": {
+      "name": "launchpad_application_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "launchpad_application_id": {
+          "name": "launchpad_application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "launchpad_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SUBMITTED'"
+        },
+        "declined_by": {
+          "name": "declined_by",
+          "type": "application_declined_by",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "launchpad_application_log_application_id_idx": {
+          "name": "launchpad_application_log_application_id_idx",
+          "columns": [
+            {
+              "expression": "launchpad_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "launchpad_application_log_created_by_idx": {
+          "name": "launchpad_application_log_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "launchpad_application_log_launchpad_application_id_launchpad_application_id_fk": {
+          "name": "launchpad_application_log_launchpad_application_id_launchpad_application_id_fk",
+          "tableFrom": "launchpad_application_log",
+          "tableTo": "launchpad_application",
+          "columnsFrom": [
+            "launchpad_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "launchpad_application_log_created_by_user_id_fk": {
+          "name": "launchpad_application_log_created_by_user_id_fk",
+          "tableFrom": "launchpad_application_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_gender": {
+      "name": "user_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.social_link_platform": {
+      "name": "social_link_platform",
+      "schema": "public",
+      "values": [
+        "website",
+        "linkedin",
+        "twitter",
+        "facebook"
+      ]
+    },
+    "public.profile_visibility": {
+      "name": "profile_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "members",
+        "private"
+      ]
+    },
+    "public.forum_answer_status": {
+      "name": "forum_answer_status",
+      "schema": "public",
+      "values": [
+        "PUBLISHED",
+        "DELETED"
+      ]
+    },
+    "public.forum_answer_vote_type": {
+      "name": "forum_answer_vote_type",
+      "schema": "public",
+      "values": [
+        "UPVOTE",
+        "DOWNVOTE"
+      ]
+    },
+    "public.forum_category_status": {
+      "name": "forum_category_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED",
+        "HIDDEN"
+      ]
+    },
+    "public.forum_question_status": {
+      "name": "forum_question_status",
+      "schema": "public",
+      "values": [
+        "PUBLISHED",
+        "CLOSED",
+        "DELETED"
+      ]
+    },
+    "public.forum_question_vote_type": {
+      "name": "forum_question_vote_type",
+      "schema": "public",
+      "values": [
+        "UPVOTE",
+        "DOWNVOTE"
+      ]
+    },
+    "public.application_declined_by": {
+      "name": "application_declined_by",
+      "schema": "public",
+      "values": [
+        "POSTER",
+        "APPLICANT"
+      ]
+    },
+    "public.volunteer_category_status": {
+      "name": "volunteer_category_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED",
+        "HIDDEN"
+      ]
+    },
+    "public.volunteer_application_status": {
+      "name": "volunteer_application_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "APPROVED",
+        "DECLINED",
+        "CONFIRMED",
+        "COMPLETED",
+        "WITHDRAWN"
+      ]
+    },
+    "public.volunteer_opportunity_status": {
+      "name": "volunteer_opportunity_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "LIVE",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "CANCELED",
+        "DELETED"
+      ]
+    },
+    "public.point_systems_mode": {
+      "name": "point_systems_mode",
+      "schema": "public",
+      "values": [
+        "action",
+        "support"
+      ]
+    },
+    "public.point_transactions_action_type": {
+      "name": "point_transactions_action_type",
+      "schema": "public",
+      "values": [
+        "purchase_tk_merch",
+        "purchase_marketplace",
+        "purchase_new_merchant_bonus",
+        "purchase_service",
+        "leave_review",
+        "merchant_verified",
+        "course_published",
+        "course_completed",
+        "resource_approved",
+        "forum_question_posted",
+        "forum_first_question_bonus",
+        "forum_participation",
+        "forum_helpful_answer",
+        "forum_best_answer",
+        "forum_answer_upvotes",
+        "forum_question_upvotes",
+        "volunteer_opportunity_posted",
+        "volunteer_registered",
+        "volunteer_mission_completed",
+        "volunteer_5star_bonus",
+        "launchpad_completion_proposer",
+        "launchpad_completion_participant",
+        "launchpad_project_validated_proposer",
+        "launchpad_project_validated_participant",
+        "mentorship_session_mentor",
+        "mentorship_session_mentee",
+        "mentorship_5star_bonus",
+        "mentorship_review_bonus",
+        "event_attended_khmer_talk",
+        "event_attended_networking",
+        "event_attended_discover",
+        "event_organised",
+        "event_organised_rating_bonus",
+        "khmer_talk_speaker",
+        "referral_active_member",
+        "welcome_profile_complete",
+        "tier_advancement_bonus",
+        "redemption_deduction"
+      ]
+    },
+    "public.point_transactions_mode": {
+      "name": "point_transactions_mode",
+      "schema": "public",
+      "values": [
+        "action",
+        "support"
+      ]
+    },
+    "public.point_transactions_pool": {
+      "name": "point_transactions_pool",
+      "schema": "public",
+      "values": [
+        "active",
+        "legacy",
+        "tier"
+      ]
+    },
+    "public.launchpad_category_status": {
+      "name": "launchpad_category_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "ARCHIVED",
+        "HIDDEN"
+      ]
+    },
+    "public.launchpad_status": {
+      "name": "launchpad_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "LIVE",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "CANCELED",
+        "DELETED"
+      ]
+    },
+    "public.launchpad_application_status": {
+      "name": "launchpad_application_status",
+      "schema": "public",
+      "values": [
+        "SUBMITTED",
+        "UNDER_REVIEW",
+        "APPROVED",
+        "DECLINED",
+        "CONFIRMED",
+        "COMPLETED",
+        "WITHDRAWN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/main/meta/_journal.json
+++ b/drizzle/main/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1779423690408,
       "tag": "0045_famous_overlord",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1779501608893,
+      "tag": "0046_lying_microchip",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/forum.ts
+++ b/src/db/schema/forum.ts
@@ -167,7 +167,12 @@ export const forumQuestionSave = pgTable(
       table.saverId,
     ),
     index("forum_question_save_question_idx").using("btree", table.questionId),
-    index("forum_question_save_saver_idx").using("btree", table.saverId),
+    index("forum_question_save_saver_created_question_idx").using(
+      "btree",
+      table.saverId,
+      table.createdAt,
+      table.questionId,
+    ),
   ],
 );
 

--- a/src/db/schema/launchpad/launchpad.ts
+++ b/src/db/schema/launchpad/launchpad.ts
@@ -162,6 +162,11 @@ export const launchpadSave = pgTable(
       table.saverId,
     ),
     index("launchpad_save_launchpad_idx").using("btree", table.launchpadId),
-    index("launchpad_save_saver_idx").using("btree", table.saverId),
+    index("launchpad_save_saver_created_launchpad_idx").using(
+      "btree",
+      table.saverId,
+      table.createdAt,
+      table.launchpadId,
+    ),
   ],
 );

--- a/src/db/schema/volunteer/volunteer-opportunities.ts
+++ b/src/db/schema/volunteer/volunteer-opportunities.ts
@@ -174,9 +174,11 @@ export const volunteerOpportunitySave = pgTable(
       "btree",
       table.opportunityId,
     ),
-    index("volunteer_opportunity_save_saver_idx").using(
+    index("volunteer_opportunity_save_saver_created_opportunity_idx").using(
       "btree",
       table.saverId,
+      table.createdAt,
+      table.opportunityId,
     ),
   ],
 );

--- a/src/modules/myspace/myspace.router.ts
+++ b/src/modules/myspace/myspace.router.ts
@@ -14,6 +14,12 @@ import {
   recentActivityErrorResponseSchema,
 } from "../recent-activity/recent-activity.schema";
 import { handleGetRecentActivities } from "../recent-activity/recent-activity.service";
+import {
+  getSavedItemsQuerySchema,
+  getSavedItemsResponseSchema,
+  savedItemsErrorResponseSchema,
+} from "./schema/saved.schema";
+import { handleGetSavedItems } from "./saved.service";
 
 export const myspaceRouter = new OpenAPIHono<AppBindings>();
 
@@ -176,6 +182,60 @@ const getRecentActivitiesRoute = createRoute({
   },
 });
 
+const getSavedItemsRoute = createRoute({
+  method: "get",
+  path: "/saved",
+  tags: ["My Space"],
+  middleware: [requireAccessToken],
+  security: [{ BearerAuth: [] }],
+  request: {
+    query: getSavedItemsQuerySchema,
+  },
+  responses: {
+    200: {
+      description:
+        "Unified list of saved projects, volunteer opportunities, and forum questions",
+      content: {
+        "application/json": {
+          schema: getSavedItemsResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: "Validation failed",
+      content: {
+        "application/json": {
+          schema: savedItemsErrorResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: authProtectedErrorResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: "Onboarding required",
+      content: {
+        "application/json": {
+          schema: authProtectedErrorResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: "Internal server error",
+      content: {
+        "application/json": {
+          schema: savedItemsErrorResponseSchema,
+        },
+      },
+    },
+  },
+});
+
 myspaceRouter.openapi(getProfileRoute, async (c) => {
   return (await handleGetProfile(c)) as any;
 });
@@ -187,4 +247,9 @@ myspaceRouter.openapi(updateProfileRoute, async (c) => {
 
 myspaceRouter.openapi(getRecentActivitiesRoute, async (c) => {
   return (await handleGetRecentActivities(c)) as any;
+});
+
+myspaceRouter.openapi(getSavedItemsRoute, async (c) => {
+  const query = c.req.valid("query");
+  return (await handleGetSavedItems(c, query)) as any;
 });

--- a/src/modules/myspace/saved.query.ts
+++ b/src/modules/myspace/saved.query.ts
@@ -1,0 +1,748 @@
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+  type SQL,
+  type SQLWrapper,
+} from "drizzle-orm";
+import { env } from "../../config/env";
+import { db } from "../../db";
+import {
+  city,
+  country,
+  forumCategory,
+  forumQuestion,
+  forumQuestionSave,
+  forumQuestionTag,
+  forumQuestionVote,
+  forumTag,
+  launchpad,
+  launchpadCategory,
+  launchpadRole,
+  launchpadSave,
+  user,
+  userProfile,
+  volunteerApplication,
+  volunteerCategory,
+  volunteerOpportunity,
+  volunteerOpportunitySave,
+  volunteerRole,
+} from "../../db/schema";
+import {
+  normalizePaginationTotal,
+  type CursorPagination,
+} from "../../utils/pagination.helper";
+import {
+  encodeSavedItemsPageCursor,
+  type GetSavedItemsQuery,
+  type SavedItemType,
+  type SavedItemsPageCursor,
+} from "./schema/saved.schema";
+
+const TYPE_ORDER: Record<SavedItemType, number> = {
+  project: 0,
+  volunteer: 1,
+  forum: 2,
+};
+
+const VISIBLE_FORUM_QUESTION_STATUSES = ["PUBLISHED", "CLOSED"] as const;
+const CAMBODIA_NORMALIZED_NAME = env.VOLUNTEER_COUNTRY_NORMALIZED_NAME;
+
+type SavedProjectItem = {
+  id: string;
+  name: string;
+  description: string | null;
+  deadline: string | null;
+  status: "DRAFT" | "LIVE" | "IN_PROGRESS" | "COMPLETED" | "CANCELED";
+  logoKey: string | null;
+  coverKey: string | null;
+  documentKeys: string[];
+  documentNames: string[];
+  phoneNumber: string | null;
+  email: string | null;
+  telegramUsername: string | null;
+  createdBy: {
+    id: string;
+    name: string;
+    avatarKey: string | null;
+    launchpadCount: number;
+  };
+  createdAt: string;
+  category?: {
+    id: string;
+    name: string;
+  };
+  city?: {
+    id: string;
+    name: string;
+  };
+  totalRoles: number;
+  totalView: number;
+  isSaved: true;
+  savedAt: string;
+};
+
+type SavedVolunteerItem = {
+  id: string;
+  title: string;
+  overview: string;
+  startDate: string | null;
+  endDate: string | null;
+  commitmentLabel: string | null;
+  commitmentDescription: string | null;
+  applicationDeadline: string;
+  applicationCount: number;
+  capacity: number;
+  filled: boolean;
+  totalView: number;
+  coverImageKey: string;
+  createdAt: string;
+  viewerSave: true;
+  category: {
+    id: string;
+    name: string;
+  };
+  location: {
+    id: string;
+    name: string;
+  };
+};
+
+type SavedForumItem = {
+  id: string;
+  title: string;
+  body: string;
+  imageKey: string | null;
+  status: "PUBLISHED" | "CLOSED" | "DELETED";
+  upvoteCount: number;
+  downvoteCount: number;
+  answerCount: number;
+  bestAnswerId: string | null;
+  bestAnswerSelectedAt: string | null;
+  score: number;
+  viewerVote: "UPVOTE" | "DOWNVOTE" | null;
+  viewerSave: true;
+  category: {
+    id: string;
+    name: string;
+  };
+  author: {
+    id: string;
+    name: string;
+    avatarKey: string | null;
+  };
+  tags: Array<{
+    id: string;
+    name: string;
+  }>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SavedItem =
+  | {
+      type: "project";
+      savedAt: string;
+      id: string;
+      item: SavedProjectItem;
+    }
+  | {
+      type: "volunteer";
+      savedAt: string;
+      id: string;
+      item: SavedVolunteerItem;
+    }
+  | {
+      type: "forum";
+      savedAt: string;
+      id: string;
+      item: SavedForumItem;
+    };
+
+export type SavedItemsResult = {
+  items: Array<Omit<SavedItem, "id">>;
+  pagination: CursorPagination;
+};
+
+function toInteger(value: unknown, fallback = 0): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function toIsoDateTimeString(value: string): string {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : value;
+}
+
+function toNullableIsoDateTimeString(value: string | null): string | null {
+  return value === null ? null : toIsoDateTimeString(value);
+}
+
+function resolveAuthorName(row: {
+  authorDisplayName: string | null;
+  authorFullName: string;
+}) {
+  const displayName = row.authorDisplayName?.trim();
+  const fullName = row.authorFullName.trim();
+  return displayName && displayName.length > 0 ? displayName : fullName;
+}
+
+function buildSavedCursorFilter(
+  type: SavedItemType,
+  savedAtColumn: SQLWrapper,
+  idColumn: SQLWrapper,
+  cursor: SavedItemsPageCursor | undefined,
+) {
+  if (!cursor) {
+    return undefined;
+  }
+
+  if (TYPE_ORDER[type] > TYPE_ORDER[cursor.type]) {
+    return sql`(${savedAtColumn} < ${cursor.savedAt}::timestamptz OR ${savedAtColumn} = ${cursor.savedAt}::timestamptz)`;
+  }
+
+  if (TYPE_ORDER[type] < TYPE_ORDER[cursor.type]) {
+    return sql`${savedAtColumn} < ${cursor.savedAt}::timestamptz`;
+  }
+
+  return sql`(${savedAtColumn} < ${cursor.savedAt}::timestamptz OR (${savedAtColumn} = ${cursor.savedAt}::timestamptz AND ${idColumn} < ${cursor.id}::uuid))`;
+}
+
+function compareSavedItems(left: SavedItem, right: SavedItem) {
+  const savedAtDelta =
+    Date.parse(right.savedAt) - Date.parse(left.savedAt);
+  if (savedAtDelta !== 0) {
+    return savedAtDelta;
+  }
+
+  const typeDelta = TYPE_ORDER[left.type] - TYPE_ORDER[right.type];
+  if (typeDelta !== 0) {
+    return typeDelta;
+  }
+
+  if (right.id > left.id) {
+    return 1;
+  }
+  if (right.id < left.id) {
+    return -1;
+  }
+  return 0;
+}
+
+function buildPagination(
+  rows: SavedItem[],
+  limit: number,
+  total: number,
+): SavedItemsResult {
+  const sortedRows = [...rows].sort(compareSavedItems);
+  const hasMore = sortedRows.length > limit;
+  const pageRows = hasMore ? sortedRows.slice(0, limit) : sortedRows;
+  const lastRow = pageRows.length > 0 ? pageRows[pageRows.length - 1] : null;
+
+  return {
+    items: pageRows.map(({ id: _id, ...row }) => row),
+    pagination: {
+      limit,
+      hasMore,
+      nextCursor:
+        hasMore && lastRow
+          ? encodeSavedItemsPageCursor({
+              savedAt: lastRow.savedAt,
+              type: lastRow.type,
+              id: lastRow.id,
+            })
+          : null,
+      total,
+    },
+  };
+}
+
+async function countSavedProjects(userId: string) {
+  const [result] = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(launchpadSave)
+    .innerJoin(launchpad, eq(launchpad.id, launchpadSave.launchpadId))
+    .where(and(eq(launchpadSave.saverId, userId), isNull(launchpad.deletedAt)));
+
+  return normalizePaginationTotal(result?.total);
+}
+
+async function findSavedProjects(
+  userId: string,
+  limit: number,
+  cursor: SavedItemsPageCursor | undefined,
+): Promise<SavedItem[]> {
+  const cursorFilter = buildSavedCursorFilter(
+    "project",
+    launchpadSave.createdAt,
+    launchpad.id,
+    cursor,
+  );
+  const filters: SQL<unknown>[] = [
+    eq(launchpadSave.saverId, userId),
+    isNull(launchpad.deletedAt),
+  ];
+
+  if (cursorFilter) {
+    filters.push(cursorFilter);
+  }
+
+  const launchpadCountSubquery = db
+    .select({
+      userId: launchpad.createdBy,
+      count: sql<number>`cast(count(${launchpad.id}) as int)`.as("count"),
+    })
+    .from(launchpad)
+    .where(isNull(launchpad.deletedAt))
+    .groupBy(launchpad.createdBy)
+    .as("launchpad_count");
+
+  const rows = await db
+    .select({
+      launchpad,
+      category: {
+        id: launchpadCategory.id,
+        name: launchpadCategory.name,
+      },
+      city: {
+        id: city.id,
+        name: city.name,
+      },
+      createdByUser: user,
+      createdByProfile: userProfile,
+      launchpadCount: sql<number>`coalesce(${launchpadCountSubquery.count}, 0)`,
+      totalRoles: sql<number>`cast(count(${launchpadRole.id}) as int)`.as(
+        "totalRoles",
+      ),
+      savedAt: launchpadSave.createdAt,
+    })
+    .from(launchpadSave)
+    .innerJoin(launchpad, eq(launchpad.id, launchpadSave.launchpadId))
+    .leftJoin(launchpadCategory, eq(launchpad.categoryId, launchpadCategory.id))
+    .leftJoin(city, eq(launchpad.cityId, city.id))
+    .leftJoin(user, eq(launchpad.createdBy, user.id))
+    .leftJoin(userProfile, eq(user.id, userProfile.userId))
+    .leftJoin(
+      launchpadCountSubquery,
+      eq(user.id, launchpadCountSubquery.userId),
+    )
+    .leftJoin(launchpadRole, eq(launchpad.id, launchpadRole.launchpadId))
+    .where(and(...filters))
+    .groupBy(
+      launchpad.id,
+      launchpadCategory.id,
+      city.id,
+      user.id,
+      userProfile.id,
+      launchpadCountSubquery.count,
+      launchpadSave.createdAt,
+    )
+    .orderBy(desc(launchpadSave.createdAt), desc(launchpad.id))
+    .limit(limit + 1);
+
+  return rows.map((row) => {
+    const savedAt = toIsoDateTimeString(row.savedAt);
+    const item: SavedProjectItem = {
+      id: row.launchpad.id,
+      name: row.launchpad.name,
+      description: row.launchpad.description,
+      deadline: toNullableIsoDateTimeString(row.launchpad.deadline),
+      status: row.launchpad.status as SavedProjectItem["status"],
+      logoKey: row.launchpad.logoKey,
+      coverKey: row.launchpad.coverKey,
+      documentKeys: row.launchpad.documentKeys as string[],
+      documentNames: row.launchpad.documentNames as string[],
+      phoneNumber: row.launchpad.phoneNumber,
+      email: row.launchpad.email,
+      telegramUsername: row.launchpad.telegramUsername,
+      createdBy: row.createdByUser
+        ? {
+            id: row.createdByUser.id,
+            name: row.createdByUser.name,
+            avatarKey: row.createdByProfile?.avatarKey ?? null,
+            launchpadCount: row.launchpadCount ?? 0,
+          }
+        : {
+            id: row.launchpad.createdBy,
+            name: "Unknown",
+            avatarKey: null,
+            launchpadCount: 0,
+          },
+      createdAt: toIsoDateTimeString(row.launchpad.createdAt),
+      category: row.category
+        ? {
+            id: row.category.id,
+            name: row.category.name,
+          }
+        : undefined,
+      city: row.city
+        ? {
+            id: row.city.id,
+            name: row.city.name,
+          }
+        : undefined,
+      totalRoles: toInteger(row.totalRoles),
+      totalView: toInteger(row.launchpad.totalView),
+      isSaved: true,
+      savedAt,
+    };
+
+    return {
+      type: "project",
+      savedAt,
+      id: row.launchpad.id,
+      item,
+    };
+  });
+}
+
+async function countSavedVolunteerOpportunities(userId: string) {
+  const [result] = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(volunteerOpportunitySave)
+    .innerJoin(
+      volunteerOpportunity,
+      eq(volunteerOpportunity.id, volunteerOpportunitySave.opportunityId),
+    )
+    .innerJoin(
+      volunteerCategory,
+      eq(volunteerCategory.id, volunteerOpportunity.categoryId),
+    )
+    .innerJoin(city, eq(city.id, volunteerOpportunity.cityId))
+    .innerJoin(country, eq(country.id, city.countryId))
+    .where(
+      and(
+        eq(volunteerOpportunitySave.saverId, userId),
+        eq(volunteerOpportunity.status, "LIVE"),
+        isNull(volunteerOpportunity.deletedAt),
+        eq(volunteerCategory.status, "ACTIVE"),
+        eq(city.isActive, true),
+        eq(country.isActive, true),
+        eq(country.normalizedName, CAMBODIA_NORMALIZED_NAME),
+        isNotNull(volunteerOpportunity.publishedAt),
+      ),
+    );
+
+  return normalizePaginationTotal(result?.total);
+}
+
+async function getVolunteerApplicationCounts(opportunityIds: string[]) {
+  const uniqueOpportunityIds = [...new Set(opportunityIds)];
+  if (uniqueOpportunityIds.length === 0) {
+    return new Map<string, number>();
+  }
+
+  const rows = await db
+    .select({
+      opportunityId: volunteerApplication.opportunityId,
+      applicationCount: sql<number>`count(*)::int`.as("application_count"),
+    })
+    .from(volunteerApplication)
+    .where(
+      and(
+        inArray(volunteerApplication.opportunityId, uniqueOpportunityIds),
+        eq(volunteerApplication.status, "CONFIRMED"),
+      ),
+    )
+    .groupBy(volunteerApplication.opportunityId);
+
+  return new Map(
+    rows.map((row) => [row.opportunityId, toInteger(row.applicationCount)]),
+  );
+}
+
+async function getVolunteerCapacities(opportunityIds: string[]) {
+  const uniqueOpportunityIds = [...new Set(opportunityIds)];
+  if (uniqueOpportunityIds.length === 0) {
+    return new Map<string, number>();
+  }
+
+  const rows = await db
+    .select({
+      opportunityId: volunteerRole.opportunityId,
+      capacity:
+        sql<number>`coalesce(sum(${volunteerRole.capacity}), 0)::int`.as(
+          "capacity",
+        ),
+    })
+    .from(volunteerRole)
+    .where(inArray(volunteerRole.opportunityId, uniqueOpportunityIds))
+    .groupBy(volunteerRole.opportunityId);
+
+  return new Map(
+    rows.map((row) => [row.opportunityId, toInteger(row.capacity)]),
+  );
+}
+
+async function findSavedVolunteerOpportunities(
+  userId: string,
+  limit: number,
+  cursor: SavedItemsPageCursor | undefined,
+): Promise<SavedItem[]> {
+  const cursorFilter = buildSavedCursorFilter(
+    "volunteer",
+    volunteerOpportunitySave.createdAt,
+    volunteerOpportunity.id,
+    cursor,
+  );
+  const filters: SQL<unknown>[] = [
+    eq(volunteerOpportunitySave.saverId, userId),
+    eq(volunteerOpportunity.status, "LIVE"),
+    isNull(volunteerOpportunity.deletedAt),
+    eq(volunteerCategory.status, "ACTIVE"),
+    eq(city.isActive, true),
+    eq(country.isActive, true),
+    eq(country.normalizedName, CAMBODIA_NORMALIZED_NAME),
+    isNotNull(volunteerOpportunity.publishedAt),
+  ];
+
+  if (cursorFilter) {
+    filters.push(cursorFilter);
+  }
+
+  const rows = await db
+    .select({
+      opportunity: volunteerOpportunity,
+      category: {
+        id: volunteerCategory.id,
+        name: volunteerCategory.name,
+      },
+      location: {
+        id: city.id,
+        name: city.name,
+      },
+      savedAt: volunteerOpportunitySave.createdAt,
+    })
+    .from(volunteerOpportunitySave)
+    .innerJoin(
+      volunteerOpportunity,
+      eq(volunteerOpportunity.id, volunteerOpportunitySave.opportunityId),
+    )
+    .innerJoin(
+      volunteerCategory,
+      eq(volunteerCategory.id, volunteerOpportunity.categoryId),
+    )
+    .innerJoin(city, eq(city.id, volunteerOpportunity.cityId))
+    .innerJoin(country, eq(country.id, city.countryId))
+    .where(and(...filters))
+    .orderBy(desc(volunteerOpportunitySave.createdAt), desc(volunteerOpportunity.id))
+    .limit(limit + 1);
+
+  const opportunityIds = rows.map((row) => row.opportunity.id);
+  const [applicationCountByOpportunityId, capacityByOpportunityId] =
+    await Promise.all([
+      getVolunteerApplicationCounts(opportunityIds),
+      getVolunteerCapacities(opportunityIds),
+    ]);
+
+  return rows.map((row) => {
+    const savedAt = toIsoDateTimeString(row.savedAt);
+    const item: SavedVolunteerItem = {
+      id: row.opportunity.id,
+      title: row.opportunity.title,
+      overview: row.opportunity.overview,
+      startDate: toNullableIsoDateTimeString(row.opportunity.startDate),
+      endDate: toNullableIsoDateTimeString(row.opportunity.endDate),
+      commitmentLabel: row.opportunity.commitmentLabel,
+      commitmentDescription: row.opportunity.commitmentDescription,
+      applicationDeadline: toIsoDateTimeString(
+        row.opportunity.applicationDeadline,
+      ),
+      applicationCount:
+        applicationCountByOpportunityId.get(row.opportunity.id) ?? 0,
+      capacity: capacityByOpportunityId.get(row.opportunity.id) ?? 0,
+      filled: row.opportunity.filled,
+      totalView: toInteger(row.opportunity.totalView),
+      coverImageKey: row.opportunity.coverImageKey,
+      createdAt: toIsoDateTimeString(row.opportunity.createdAt),
+      viewerSave: true,
+      category: row.category,
+      location: row.location,
+    };
+
+    return {
+      type: "volunteer",
+      savedAt,
+      id: row.opportunity.id,
+      item,
+    };
+  });
+}
+
+async function countSavedForumQuestions(userId: string) {
+  const [result] = await db
+    .select({ total: sql<number>`count(*)::int` })
+    .from(forumQuestionSave)
+    .innerJoin(forumQuestion, eq(forumQuestion.id, forumQuestionSave.questionId))
+    .where(
+      and(
+        eq(forumQuestionSave.saverId, userId),
+        inArray(forumQuestion.status, VISIBLE_FORUM_QUESTION_STATUSES),
+      ),
+    );
+
+  return normalizePaginationTotal(result?.total);
+}
+
+async function getForumTagsByQuestionIds(questionIds: string[]) {
+  const uniqueQuestionIds = [...new Set(questionIds)];
+  if (uniqueQuestionIds.length === 0) {
+    return new Map<string, Array<{ id: string; name: string }>>();
+  }
+
+  const rows = await db
+    .select({
+      questionId: forumQuestionTag.questionId,
+      tag: {
+        id: forumTag.id,
+        name: forumTag.name,
+      },
+    })
+    .from(forumQuestionTag)
+    .innerJoin(forumTag, eq(forumTag.id, forumQuestionTag.tagId))
+    .where(inArray(forumQuestionTag.questionId, uniqueQuestionIds));
+
+  const tagsByQuestionId = new Map<string, Array<{ id: string; name: string }>>();
+  for (const row of rows) {
+    const tags = tagsByQuestionId.get(row.questionId);
+    if (!tags) {
+      tagsByQuestionId.set(row.questionId, [row.tag]);
+      continue;
+    }
+
+    tags.push(row.tag);
+  }
+
+  return tagsByQuestionId;
+}
+
+async function findSavedForumQuestions(
+  userId: string,
+  limit: number,
+  cursor: SavedItemsPageCursor | undefined,
+): Promise<SavedItem[]> {
+  const cursorFilter = buildSavedCursorFilter(
+    "forum",
+    forumQuestionSave.createdAt,
+    forumQuestion.id,
+    cursor,
+  );
+  const filters: SQL<unknown>[] = [
+    eq(forumQuestionSave.saverId, userId),
+    inArray(forumQuestion.status, VISIBLE_FORUM_QUESTION_STATUSES),
+  ];
+
+  if (cursorFilter) {
+    filters.push(cursorFilter);
+  }
+
+  const rows = await db
+    .select({
+      question: forumQuestion,
+      categoryName: forumCategory.name,
+      authorDisplayName: userProfile.displayName,
+      authorFullName: user.name,
+      authorAvatarKey: userProfile.avatarKey,
+      viewerVoteType: forumQuestionVote.voteType,
+      savedAt: forumQuestionSave.createdAt,
+    })
+    .from(forumQuestionSave)
+    .innerJoin(forumQuestion, eq(forumQuestion.id, forumQuestionSave.questionId))
+    .innerJoin(forumCategory, eq(forumCategory.id, forumQuestion.categoryId))
+    .innerJoin(user, eq(user.id, forumQuestion.authorId))
+    .leftJoin(userProfile, eq(userProfile.userId, user.id))
+    .leftJoin(
+      forumQuestionVote,
+      and(
+        eq(forumQuestionVote.questionId, forumQuestion.id),
+        eq(forumQuestionVote.voterId, userId),
+      ),
+    )
+    .where(and(...filters))
+    .orderBy(desc(forumQuestionSave.createdAt), desc(forumQuestion.id))
+    .limit(limit + 1);
+
+  const tagsByQuestionId = await getForumTagsByQuestionIds(
+    rows.map((row) => row.question.id),
+  );
+
+  return rows.map((row) => {
+    const savedAt = toIsoDateTimeString(row.savedAt);
+    const item: SavedForumItem = {
+      id: row.question.id,
+      title: row.question.title,
+      body: row.question.body,
+      imageKey: row.question.imageKey,
+      status: row.question.status as SavedForumItem["status"],
+      upvoteCount: row.question.upvoteCount,
+      downvoteCount: row.question.downvoteCount,
+      answerCount: row.question.answerCount,
+      bestAnswerId: row.question.bestAnswerId,
+      bestAnswerSelectedAt: toNullableIsoDateTimeString(
+        row.question.bestAnswerSelectedAt,
+      ),
+      score: row.question.upvoteCount - row.question.downvoteCount,
+      viewerVote: row.viewerVoteType,
+      viewerSave: true,
+      category: {
+        id: row.question.categoryId,
+        name: row.categoryName,
+      },
+      author: {
+        id: row.question.authorId,
+        name: resolveAuthorName(row),
+        avatarKey: row.authorAvatarKey,
+      },
+      tags: tagsByQuestionId.get(row.question.id) ?? [],
+      createdAt: toIsoDateTimeString(row.question.createdAt),
+      updatedAt: toIsoDateTimeString(row.question.updatedAt),
+    };
+
+    return {
+      type: "forum",
+      savedAt,
+      id: row.question.id,
+      item,
+    };
+  });
+}
+
+export async function getSavedItems(
+  userId: string,
+  query: GetSavedItemsQuery,
+): Promise<SavedItemsResult> {
+  const fetchLimit = query.limit + 1;
+  const shouldFetchProject =
+    query.filter === "all" || query.filter === "project";
+  const shouldFetchVolunteer =
+    query.filter === "all" || query.filter === "volunteer";
+  const shouldFetchForum = query.filter === "all" || query.filter === "forum";
+
+  const [projects, volunteers, forumQuestions, projectTotal, volunteerTotal, forumTotal] =
+    await Promise.all([
+      shouldFetchProject
+        ? findSavedProjects(userId, fetchLimit, query.cursor)
+        : Promise.resolve([]),
+      shouldFetchVolunteer
+        ? findSavedVolunteerOpportunities(userId, fetchLimit, query.cursor)
+        : Promise.resolve([]),
+      shouldFetchForum
+        ? findSavedForumQuestions(userId, fetchLimit, query.cursor)
+        : Promise.resolve([]),
+      shouldFetchProject ? countSavedProjects(userId) : Promise.resolve(0),
+      shouldFetchVolunteer
+        ? countSavedVolunteerOpportunities(userId)
+        : Promise.resolve(0),
+      shouldFetchForum ? countSavedForumQuestions(userId) : Promise.resolve(0),
+    ]);
+
+  return buildPagination(
+    [...projects, ...volunteers, ...forumQuestions],
+    query.limit,
+    projectTotal + volunteerTotal + forumTotal,
+  );
+}

--- a/src/modules/myspace/saved.service.ts
+++ b/src/modules/myspace/saved.service.ts
@@ -1,0 +1,22 @@
+import type { Context } from "hono";
+import { getAuthUserId } from "../auth/utils/get-auth";
+import { getSavedItems } from "./saved.query";
+import type { GetSavedItemsQuery } from "./schema/saved.schema";
+
+export async function handleGetSavedItems(
+  c: Context,
+  query: GetSavedItemsQuery,
+) {
+  const authResult = getAuthUserId(c);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  try {
+    const result = await getSavedItems(authResult.userId, query);
+    return c.json({ ok: true, ...result }, 200);
+  } catch (err) {
+    console.error("Failed to get saved items", err);
+    return c.json({ ok: false, error: "Internal server error" }, 500);
+  }
+}

--- a/src/modules/myspace/schema/saved.schema.ts
+++ b/src/modules/myspace/schema/saved.schema.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+import { FORUM_UUID_RE } from "../../forum/lib/constants";
+import { questionResponseSchema } from "../../forum/questions/schema/questions.response.schema";
+import { volunteerOpportunityListItemResponseSchema } from "../../volunteer/post-volunteer/schema/opportunities.response.schema";
+
+const MAX_SAVED_ITEMS_PAGE_SIZE = 50;
+const DEFAULT_SAVED_ITEMS_PAGE_SIZE = 20;
+
+export const savedItemTypeSchema = z.enum(["project", "volunteer", "forum"]);
+export const savedItemsFilterSchema = z
+  .enum(["all", "project", "volunteer", "forum"])
+  .default("all");
+
+export type SavedItemType = z.infer<typeof savedItemTypeSchema>;
+
+export type SavedItemsPageCursor = {
+  savedAt: string;
+  type: SavedItemType;
+  id: string;
+};
+
+const savedItemsPageCursorSchema = z.object({
+  savedAt: z.string().datetime({ offset: true }),
+  type: savedItemTypeSchema,
+  id: z.string().regex(FORUM_UUID_RE),
+});
+
+function normalizeSavedItemsCursorTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+}
+
+export function encodeSavedItemsPageCursor(
+  cursor: SavedItemsPageCursor,
+): string {
+  const savedAt = normalizeSavedItemsCursorTimestamp(cursor.savedAt);
+  if (!savedAt) {
+    throw new Error("Cannot encode saved items page cursor with invalid savedAt");
+  }
+
+  return Buffer.from(
+    JSON.stringify({
+      savedAt,
+      type: cursor.type,
+      id: cursor.id,
+    }),
+    "utf8",
+  ).toString("base64url");
+}
+
+function decodeSavedItemsPageCursor(raw: string): SavedItemsPageCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const cursor = savedItemsPageCursorSchema.safeParse(parsed);
+    return cursor.success ? cursor.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export const getSavedItemsQuerySchema = z
+  .object({
+    filter: savedItemsFilterSchema.openapi({
+      description:
+        "Saved item filter. Use all for projects, volunteer opportunities, and forum questions.",
+    }),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1, "limit must be between 1 and 50")
+      .max(MAX_SAVED_ITEMS_PAGE_SIZE, "limit must be between 1 and 50")
+      .default(DEFAULT_SAVED_ITEMS_PAGE_SIZE),
+    cursor: z.string().optional().openapi({
+      description: "Opaque pagination cursor returned by a previous response.",
+    }),
+  })
+  .superRefine((value, ctx) => {
+    const cursor = value.cursor
+      ? decodeSavedItemsPageCursor(value.cursor)
+      : undefined;
+
+    if (value.cursor && !cursor) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "cursor must be a valid pagination cursor",
+        path: ["cursor"],
+      });
+      return;
+    }
+
+    if (cursor && value.filter !== "all" && cursor.type !== value.filter) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "cursor type must match filter",
+        path: ["cursor"],
+      });
+    }
+  })
+  .transform((value) => ({
+    filter: value.filter,
+    limit: value.limit,
+    cursor: value.cursor
+      ? (decodeSavedItemsPageCursor(value.cursor) as SavedItemsPageCursor)
+      : undefined,
+  }))
+  .openapi("GetSavedItemsQuery");
+
+const savedProjectItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  deadline: z.string().datetime({ offset: true }).nullable(),
+  status: z.enum(["DRAFT", "LIVE", "IN_PROGRESS", "COMPLETED", "CANCELED"]),
+  logoKey: z.string().nullable(),
+  coverKey: z.string().nullable(),
+  documentKeys: z.array(z.string()),
+  documentNames: z.array(z.string()),
+  phoneNumber: z.string().nullable(),
+  email: z.string().nullable(),
+  telegramUsername: z.string().nullable(),
+  createdBy: z.object({
+    id: z.string(),
+    name: z.string(),
+    avatarKey: z.string().nullable(),
+    launchpadCount: z.number(),
+  }),
+  createdAt: z.string().datetime({ offset: true }),
+  category: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+    })
+    .optional(),
+  city: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+    })
+    .optional(),
+  totalRoles: z.number(),
+  totalView: z.number(),
+  isSaved: z.literal(true),
+  savedAt: z.string().datetime({ offset: true }),
+});
+
+const savedPaginationSchema = z.object({
+  limit: z.number(),
+  hasMore: z.boolean(),
+  nextCursor: z.string().nullable(),
+  total: z.number().int().nonnegative(),
+});
+
+export const getSavedItemsResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    items: z.array(
+      z.discriminatedUnion("type", [
+        z.object({
+          type: z.literal("project"),
+          savedAt: z.string().datetime({ offset: true }),
+          item: savedProjectItemSchema,
+        }),
+        z.object({
+          type: z.literal("volunteer"),
+          savedAt: z.string().datetime({ offset: true }),
+          item: volunteerOpportunityListItemResponseSchema,
+        }),
+        z.object({
+          type: z.literal("forum"),
+          savedAt: z.string().datetime({ offset: true }),
+          item: questionResponseSchema,
+        }),
+      ]),
+    ),
+    pagination: savedPaginationSchema,
+  })
+  .openapi("GetSavedItemsResponse");
+
+export const savedItemsErrorResponseSchema = z
+  .object({
+    ok: z.literal(false),
+    error: z.string(),
+  })
+  .openapi("SavedItemsErrorResponse");
+
+export type GetSavedItemsQuery = z.infer<typeof getSavedItemsQuerySchema>;


### PR DESCRIPTION
- Implemented `getSavedItems` route to fetch a unified list of saved projects, volunteer opportunities, and forum questions.
- Created query and response schemas for saved items.
- Added service to handle fetching saved items from the database.
- Updated database schemas to include new indices for improved query performance.
- Added new saved item types and pagination logic to handle multiple item types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified endpoint to retrieve all saved items across projects, volunteer opportunities, and forum questions
  * Implemented cursor-based pagination for browsing saved items
  * Added filtering options to view saved items by type or all at once

* **Performance Improvements**
  * Optimized database queries for faster retrieval of saved items with composite indexing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/florestara/true-khmer-api/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->